### PR TITLE
feat(cd): setup ci/cd

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      deployments: write
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v4
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build for Production
+        env:
+          NODE_ENV: production
+        run: npm run build
+
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/pages-action@1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          directory: ./build
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          projectName: 'fluvio-docs'
+          branch: 'main'

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -11,7 +11,7 @@ const config: Config = {
   favicon: "img/favicon.ico",
 
   // Set the production url of your site here
-  url: "https://fluvio.io/",
+  url: "https://.pages.dev",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: "/",


### PR DESCRIPTION
Makes the site available on https://fluvio-docs.pages.dev/docs/quickstart as we develop,
and sets up CD already.

<img width="1458" alt="Screenshot 2024-05-03 at 4 21 47 PM" src="https://github.com/infinyon/fluvio-docs/assets/34756077/4162a636-4a6b-4f64-9785-b58230627451">
