### PR TITLE
feat: move `/fluvio` docs to the root level

### DIFF
--- a/docs/fluvio/concepts/advanced/crds.mdx
+++ b/docs/fluvio/concepts/advanced/crds.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
-slug: /advanced/crds
 title: "CRDs"
+slug: /advanced/crds
 ---
 
 # Custom Resource Definitions

--- a/docs/fluvio/concepts/advanced/install-on-rancher.mdx
+++ b/docs/fluvio/concepts/advanced/install-on-rancher.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
-slug: /advanced/install-on-rancher
 title: "Install on Rancher Desktop"
+slug: /advanced/install-on-rancher
 ---
 
 ## Install Fluvio CLI

--- a/docs/fluvio/concepts/advanced/kubernetes.mdx
+++ b/docs/fluvio/concepts/advanced/kubernetes.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
-slug: /advanced/kubernetes
 title: "Install Fluvio on Kubernetes"
+slug: /advanced/kubernetes
 ---
 
 Fluvio is a Kubernetes-native containerized application.  There are multiple ways to install Fluvio in a kubernetes cluster.

--- a/docs/fluvio/concepts/advanced/network.mdx
+++ b/docs/fluvio/concepts/advanced/network.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
-slug: /advanced/network
 title: "Install Fluvio on Kubernetes"
+slug: /advanced/network
 ---
 
 # Fluvio Network Access

--- a/docs/fluvio/concepts/architecture/auth.mdx
+++ b/docs/fluvio/concepts/architecture/auth.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
-slug: /concepts/architecture/auth
 title: "Authentication and Authorization"
+slug: /concepts/architecture/auth
 ---
 
 When the user logs in, the client downloads a profile and extracts the user identification from the client certificate issued by the server. The authorization is driven by simple RBAC (role-based access control), which can be extended for other more advanced authorization schemes in the future.

--- a/docs/fluvio/concepts/architecture/client.mdx
+++ b/docs/fluvio/concepts/architecture/client.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 7
-slug: /concepts/architecture/client
 title: "Client Library"
+slug: /concepts/architecture/client
 ---
 
 A Fluvio client communicates with a Fluvio cluster to manage streams and to emit or receive events. The client uses a purpose-built communication protocol that is optimized for maximum performance, scalability, and low latency. Websocket is currently in the works, and future versions will provide adaptors to other protocols, such as: HTTP, gRPC, protobuf and more.

--- a/docs/fluvio/concepts/architecture/overview.mdx
+++ b/docs/fluvio/concepts/architecture/overview.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
-slug: /concepts/architecture/overview
 title: "Overview"
+slug: /concepts/architecture/overview
 ---
 
 **Fluvio Data Streaming** is a modern Cloud Native software stack designed for **high speed, real-time data** processing. Fluvio is _fast_, _scalable_, _self-healing_, _pluggable_, and _user-friendly_.

--- a/docs/fluvio/concepts/architecture/replica-assignment.mdx
+++ b/docs/fluvio/concepts/architecture/replica-assignment.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
-slug: /concepts/architecture/replica-assignment
 title: "Replica Assignment"
+slug: /concepts/architecture/replica-assignment
 ---
 
 **Replica assignment** algorithm is triggered by topic creation and it is responsible for a building a **balanced distribution** of replicas across the SPUs in a Fluvio cluster. **Replicas** from different SPUs are grouped in **replica sets**, where each replica saves a copy of a data stream. Each replica set has a leader and one or more followers that are distributed across available SPUs.

--- a/docs/fluvio/concepts/architecture/replica-election.mdx
+++ b/docs/fluvio/concepts/architecture/replica-election.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 6
-slug: /concepts/architecture/replica-election
 title: "Replica Election"
+slug: /concepts/architecture/replica-election
 ---
 
 [Replica Assignment] _assigns_ SPUs to a replica set and [Replica Election] _coordinates_ their roles. The election algorithm manages replica sets in an attempt to designate one active leader at all times. SPUs have a powerful <ins>multi-threaded engine</ins> that can process a large number of leaders and followers at the same time.

--- a/docs/fluvio/concepts/architecture/sc.mdx
+++ b/docs/fluvio/concepts/architecture/sc.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
-slug: /concepts/architecture/sc
 title: "Streaming Controller (SC)"
+slug: /concepts/architecture/sc
 ---
 
 **Streaming Controller (SC)** is the central coordinator and the **authoritative** entity of the cluster. It manages configuration changes, provisions SPUs, performs replica assignment, coordinates communication with external clients, and sends periodic reconciliation updates.

--- a/docs/fluvio/concepts/architecture/spu.mdx
+++ b/docs/fluvio/concepts/architecture/spu.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
-slug: /concepts/architecture/spu
 title: "Streaming Processing Unit (SPU)"
+slug: /concepts/architecture/spu
 ---
 
 **Streaming Processing Unit (SPU)** is responsible for processing data streams in real-time. The SPUs is designed for **horizontal scale**, where SPUs are gradually added to the cluster to accommodate higher data throughput. Each SPU **manages replicas** which represent the lowest unit of a data stream. Replicas are copies of data streams that are evenly distributed across SPUs.

--- a/docs/fluvio/concepts/batching.mdx
+++ b/docs/fluvio/concepts/batching.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 10
-slug: /concepts/batching
 title: "Batching"
+slug: /concepts/batching
 ---
 
 Fluvio producers try to send records in batches to reduce the number of messages sent and improve throughput. Each producer has some configurations that can be set to improve performance for a specific use case. For instance, they can be used to reduce disk usage, reduce latency, or improve throughput.

--- a/docs/fluvio/concepts/data-consistency.mdx
+++ b/docs/fluvio/concepts/data-consistency.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 11
-slug: /concepts/data-consistency
 title: "Data Consistency"
+slug: /concepts/data-consistency
 ---
 
 Data in this context is a set of records that producers send to the partition leader. The leader is responsible for receiving

--- a/docs/fluvio/concepts/delivery-semantics.mdx
+++ b/docs/fluvio/concepts/delivery-semantics.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 12
-slug: /concepts/delivery-semantics
 title: "Delivery Semantics"
+slug: /concepts/delivery-semantics
 ---
 
 The Internet, as well as other networks, is considered an unreliable communication channel. There can be delays or lost messages, and connections can fail unexpectedly.

--- a/docs/fluvio/concepts/offsets.mdx
+++ b/docs/fluvio/concepts/offsets.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 9
-slug: /concepts/offsets
 title: "Offsets"
+slug: /concepts/offsets
 ---
 
 When a record is assigned an offset, that offset permanently identifies

--- a/docs/fluvio/concepts/operations/data-retention.mdx
+++ b/docs/fluvio/concepts/operations/data-retention.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
-slug: /concepts/operations/data-retentiton
 title: "Data Retention"
+slug: /concepts/operations/data-retentiton
 ---
 
 ## Overview

--- a/docs/fluvio/concepts/operations/monitor.mdx
+++ b/docs/fluvio/concepts/operations/monitor.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
-slug: /concepts/operations/monitor
 title: "Monitor"
+slug: /concepts/operations/monitor
 ---
 
 These objects represent the state of the Fluvio cluster.

--- a/docs/fluvio/concepts/operations/troubleshooting.mdx
+++ b/docs/fluvio/concepts/operations/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
-slug: /concepts/operations/troubleshooting
 title: "Troubleshooting"
+slug: /concepts/operations/troubleshooting
 ---
 
 ## Run cluster check

--- a/docs/fluvio/concepts/operations/upgrade.mdx
+++ b/docs/fluvio/concepts/operations/upgrade.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
-slug: /concepts/operations/upgrade
 title: "Upgrade"
+slug: /concepts/operations/upgrade
 ---
 
 When upgrading to a new version of Fluvio, the first thing you need to do

--- a/docs/fluvio/concepts/partitions.mdx
+++ b/docs/fluvio/concepts/partitions.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 7
-slug: /concepts/partitions
 title: "Partitions"
+slug: /concepts/partitions
 ---
 
 **Partitions** are the unit of parallelism accessed independently by **producers** and **consumers** within a **topic**.

--- a/docs/fluvio/concepts/produce-consume.mdx
+++ b/docs/fluvio/concepts/produce-consume.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
-slug: /concepts/produce-consume
 title: "Producers and Consumers"
+slug: /concepts/produce-consume
 ---
 
 ## Producer

--- a/docs/fluvio/concepts/records.mdx
+++ b/docs/fluvio/concepts/records.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 8
-slug: /concepts/records
 title: "Records"
+slug: /concepts/records
 ---
 
 A **Record** is data that is indexed and stored for later use.

--- a/docs/fluvio/concepts/topics.mdx
+++ b/docs/fluvio/concepts/topics.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 6
-slug: /concepts/topics
 title: "Topics"
+slug: /concepts/topics
 ---
 
 **Topics** define a **data stream**. You can think of a topic as the streaming equivalent of a table in a database. Topics can be parallelized into any number of data slices called [partitions].

--- a/docs/fluvio/concepts/transformations.mdx
+++ b/docs/fluvio/concepts/transformations.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 13
-slug: /concepts/transformations
 title: "Transformations"
+slug: /concepts/transformations
 ---
 
 In Fluvio, the data transformation is done using [SmartModules] - user-defined functions compiled to WebAssembly (WASM). A group of SmartModules forms a transformation chain - sequential invocations of each SmartModule according to the order defined upon creation. The output of the first invocation becomes the input of the second, the output of the second becomes the input of the third, and so on.

--- a/docs/fluvio/how-to/install-cli-toolchain.mdx
+++ b/docs/fluvio/how-to/install-cli-toolchain.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 8
 title: "Install Fluvio CLI Toolchain"
 description: "A short tutorial for using fvm"
+slug: /how-to/install-cli-toolchain
 ---
 
 This is a short introduction to `fvm`, the Fluvio Version Manager, which allows you to use multiple versions of the Fluvio CLI toolchain.

--- a/docs/fluvio/how-to/smartmodule-basics.mdx
+++ b/docs/fluvio/how-to/smartmodule-basics.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 3
 title: "Use SmartModules"
 description: "A short tutorial on using SmartModules"
+slug: /how-to/smartmodule-basics
 ---
 
 <img src="/img/docs/how-to/smartmodule-basics/smartmodule-overview.svg" />

--- a/docs/fluvio/how-to/smartmodule-for-dev.mdx
+++ b/docs/fluvio/how-to/smartmodule-for-dev.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 4
 title: "Build your own SmartModules"
 description: "Tutorial for Rust developers on how to use Smart Module Development Kit to build your custom transformations."
+slug: /how-to/smartmodule-for-dev
 ---
 
 This tutorial expects you to already have the Fluvio CLI installed, and InfinyOn

--- a/docs/fluvio/how-to/use-connectors-in-cloud.mdx
+++ b/docs/fluvio/how-to/use-connectors-in-cloud.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 10
 title: "Use Connectors on InfinyOn Cloud"
 description: "Connectors with InfinyOn Cloud is the best option for those who want to manage their data pipelines in one place."
+slug: /how-to/use-connectors-in-cloud
 ---
 
 Connectors with [InfinyOn Cloud] is the best option for those who want to manage their data pipelines in one place.

--- a/docs/fluvio/how-to/use-connectors.mdx
+++ b/docs/fluvio/how-to/use-connectors.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 7
 title: "Use Connectors"
 description: "A short tutorial for using Connectors"
+slug: /how-to/use-connectors
 ---
 
 Ensure `fluvio` is installed and logged in to InfinyOn Cloud before proceeding. If not set up, follow the [Quick Start](/).

--- a/docs/fluvio/how-to/use-fluvio-in-docker.mdx
+++ b/docs/fluvio/how-to/use-fluvio-in-docker.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 2
 title: "Use Fluvio in Docker"
 description: "Install Fluvio Cluster with Docker Compose"
+slug: /how-to/use-fluvio-in-docker
 ---
 
 # Use Fluvio in Docker

--- a/docs/fluvio/how-to/use-infinyon-cloud.mdx
+++ b/docs/fluvio/how-to/use-infinyon-cloud.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: "Use InfinyOn Cloud"
 description: "Step-by-step instructions on how to create an account and login to InfinyOn Cloud using the CLI."
+slug: /how-to/use-infinyon-cloud
 ---
 
 # Use InfinyOn Cloud Cluster

--- a/docs/fluvio/how-to/use-secrets.mdx
+++ b/docs/fluvio/how-to/use-secrets.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 9
 title: "Use Secrets"
 description: "A short tutorial for using Secret"
+slug: /how-to/use-secrets
 ---
 
 Manage sensitive data like passwords and API keys securely in Fluvio Cloud using the `fluvio cloud secret` command. For more details, see the [Cloud documentation][cli-secret].

--- a/docs/fluvio/how-to/use-the-hub.mdx
+++ b/docs/fluvio/how-to/use-the-hub.mdx
@@ -2,6 +2,7 @@
 sidebar_position: 6
 title: "Use The Hub"
 description: "A short tutorial on InfinyOn Hub"
+slug: /how-to/use-the-hub
 ---
 
 The InfinyOn Hub serves as a centralized repository for InfinyOn SmartConnectors, SmartModules, and other extensions. It facilitates the discovery and deployment of extensions to enhance the data streaming capabilities of Fluvio. The hub provides a platform for developers and data engineers to easily access pre-built solutions or share their own extensions.

--- a/docs/fluvio/how-to/use-webhooks.mdx
+++ b/docs/fluvio/how-to/use-webhooks.mdx
@@ -1,7 +1,8 @@
 ---
 sidebar_position: 5
 title: "Use Webhooks"
-description: "A short tutorial on using SmartModules"
+description: "A short tutorial on using InfinyOn Cloud WebHooks"
+slug: /how-to/use-webhooks
 ---
 
 This tutorial assumes that `fluvio` is installed, and logged-in to InfinyOn Cloud. Follow the [Quick Start](/) to get set up.


### PR DESCRIPTION
After moving Fluvio docs under `/fluvio` we now need to specify `slug` on front matter
as `/` so every `Fluvio` doc is in the root level.