### PR TITLE
feat: copy to clipboard with custom behaviors

### DIFF
--- a/docs/fluvio/concepts/advanced/install-on-rancher.mdx
+++ b/docs/fluvio/concepts/advanced/install-on-rancher.mdx
@@ -28,15 +28,13 @@ Please make sure that the container runtime is `dockerd (moby)`. That configurat
 
 You can start a Fluvio cluster by running `fluvio cluster start`.
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio cluster start --k8 --use-k8-port-forwarding
 ```
 
 If rancher desktop is configured to manage a kubernetes cluster on a non-local host or ip, the `--proxy-addr` argument needs to provide that host dns name, or ip of that cluster.
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio cluster start --k8 --proxy-addr HOSTNAME_OR_IP
 ```
 
@@ -56,8 +54,7 @@ Let's use the Fluvio CLI to play with some basic functionality.
 
 The first thing we need to do is create a [topic].
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio topic create greetings
 topic greetings created
 ```
@@ -66,15 +63,13 @@ Now that we have a topic, we can [produce] some messages!
 
 Use the following command to send a message to the `greetings` topic:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ echo Hello, Fluvio | fluvio produce greetings
 ```
 
 Finally, we can [consume] messages back from the topic
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio consume greetings -B -d
 Consuming records from the beginning of topic 'greetings'
 Hello, Fluvio

--- a/docs/fluvio/concepts/advanced/kubernetes.mdx
+++ b/docs/fluvio/concepts/advanced/kubernetes.mdx
@@ -20,15 +20,13 @@ If you run into any problems along the way, make sure to check out our [troubles
 
 This command will install Fluvio and it's dependencies in the default namespace. This method works with many but not all kubernetes cluster types and is an opinionated set of configurations for a simple, working fluvio cluster.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio cluster start --k8
 ```
 
 For installing on a remote Kubernetes cluster where the machine running the CLI is not the local host, consider using the `--proxy-addr <DNS or IP>` option which will access the fluvio app endpoints through the specified proxy address.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio cluster start --k8 --proxy-addr <DNS or IP>
 ```
 
@@ -39,8 +37,7 @@ to a working `kubectl` context. The charts are available in the [fluvio reposito
 
 There are two charts. First is the `fluvio-sys` chart which is common to all Fluvio instances. Second is a `fluvio-app` chart which can be configured for one or more instances of clusters
 
-%copy first-line%
-```bash
+```bash copy="fl"
 helm upgrade --install fluvio-sys ./k8-util/helm/fluvio-sys
 ```
 
@@ -63,8 +60,7 @@ the scope of this guide and require modification of the helm chart values. Feel 
 
 First, install the `fluvio-sys` chart.  This only has to be done once.
 
-%copy first-line%
-```bash
+```bash copy="fl"
 helm upgrade --install fluvio-sys ./k8-util/helm/fluvio-sys
 ```
 
@@ -110,8 +106,7 @@ and so forth.
 
 To delete a Fluvio instances, supply namespace as an argument.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio cluster delete --k8 --namespace first
 ```
 

--- a/docs/fluvio/concepts/architecture/replica-assignment.mdx
+++ b/docs/fluvio/concepts/architecture/replica-assignment.mdx
@@ -208,8 +208,7 @@ Replicas are evenly distributed across SPUs. Racks with a higher number of SPUs 
 
 The following command creates a topic from a **replica assignment file**:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio topic create custom-topic --replica-assignment ./my-assignment
 ```
 

--- a/docs/fluvio/concepts/operations/data-retention.mdx
+++ b/docs/fluvio/concepts/operations/data-retention.mdx
@@ -45,13 +45,11 @@ The default retention time is `7 days`
 ### Example retention configurations
 * Delete old segments that are `6 hours` old
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio topic create test1 --retention-time "6h"
 ```
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio topic list
  NAME         TYPE      PARTITIONS  REPLICAS  RETENTION TIME  STATUS                   REASON
  test1        computed      1          1            6h        resolution::provisioned
@@ -59,13 +57,11 @@ $ fluvio topic list
 
 * Delete old segments that are a day old
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio topic create test2 --retention-time "1d"
 ```
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio topic list
  NAME         TYPE      PARTITIONS  REPLICAS  RETENTION TIME  STATUS                   REASON
  test2        computed      1          1           1day       resolution::provisioned
@@ -73,13 +69,11 @@ $ fluvio topic list
 
 * A very specific duration that is 1 day, 2 hours, 3 minutes and 4 seconds long
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio topic create test3 --retention-time "1d 2h 3m 4s"
 ```
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio topic list
  NAME         TYPE      PARTITIONS  REPLICAS  RETENTION TIME  STATUS                   REASON
  test3        computed      1          1      1day 2h 3m 4s   resolution::provisioned
@@ -101,15 +95,13 @@ The default segment size is `1 GB`
 ### Example retention configurations
 * 25 MB segment size w/ 7 day retention time
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio topic create test4 --segment-size 25000000
 ```
 
 * 36 GB segment size w/ 12 hr retention time
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio topic create test5 --segment-size "36 GB" --retention-time 12h
 ```
 
@@ -134,8 +126,7 @@ The max partition size must not be less than segment size.
 
 * 10 GB max partition size w/ 1 GB segment size (only 10 segments are allowed at any time)
 
-%copy first-line%
-```bash
+```bash copy="fl"
 fluvio topic create test6 --max-partition-size '10 GB' --segment-size '1 GB'
 ```
 

--- a/docs/fluvio/concepts/operations/monitor.mdx
+++ b/docs/fluvio/concepts/operations/monitor.mdx
@@ -11,8 +11,7 @@ These objects represent the state of the Fluvio cluster.
 
 Example:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ kubectl get pods
 NAME                         READY   STATUS    RESTARTS   AGE
 fluvio-sc-6458d598d6-qq2td   1/1     Running   0          3m35s
@@ -24,8 +23,7 @@ fluvio-spg-main-0            1/1     Running   0          3m28s
 
 Example:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ kubectl get svc
 NAME                 TYPE           CLUSTER-IP       EXTERNAL-IP      PORT(S)             AGE
 fluvio-sc-internal   ClusterIP      10.96.41.31      <none>           9004/TCP            4m18s

--- a/docs/fluvio/concepts/operations/troubleshooting.mdx
+++ b/docs/fluvio/concepts/operations/troubleshooting.mdx
@@ -10,8 +10,7 @@ To diagnose abnormal behavior, a good first step is to run `fluvio cluster check
 
 If everything is configured properly, you should see a result like this:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio cluster check
 Running pre-startup checks...
      ✅ Kubernetes config is loadable
@@ -31,13 +30,13 @@ next: run `fluvio cluster start`
 To discover errors, you should examine logs from the following components:
 
 ### SC
-%copy first-line%
-```bash
+
+```bash copy="fl"
 kubectl logs -l app=fluvio-sc
 ```
 ### SPU
-%copy first-line%
-```bash
+
+```bash copy="fl"
 kubectl logs -l app=spu
 ```
 

--- a/docs/fluvio/concepts/operations/upgrade.mdx
+++ b/docs/fluvio/concepts/operations/upgrade.mdx
@@ -9,15 +9,13 @@ is [update the Fluvio CLI] using the following command:
 
 [update the Fluvio CLI]:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio update
 ```
 
 After updating the CLI, we can upgrade the Fluvio _cluster_ using this command:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio cluster upgrade
 ```
 
@@ -29,8 +27,7 @@ your Kubernetes cluster.
 You may optionally specify a specific Fluvio chart version by adding
 the `--chart-version` argument to the upgrade command, such as the following:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio cluster upgrade --chart-version=0.8.3
 ```
 
@@ -40,7 +37,6 @@ The possible versions you may pass to `--chart-version` correspond to the
 available helm charts published on the Fluvio chart museum. You may view
 this list of releases quickly with the command:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio cluster releases list
 ```

--- a/docs/fluvio/concepts/produce-consume.mdx
+++ b/docs/fluvio/concepts/produce-consume.mdx
@@ -61,8 +61,7 @@ $ echo "Two" | fluvio produce hello-topic
 ```
 Ok, now let's read the topic from the beginning on behalf of consumer `c1`:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio consume hello-topic -c c1 -Bd
 Consuming records from 'hello-topic' starting from the beginning of log
 One
@@ -70,8 +69,7 @@ Two
 ```
 From now we can see our `c1` consumer in the consumers list:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio consumer list
   CONSUMER  TOPIC        PARTITION  OFFSET  LAST SEEN
   c1        hello-topic  0          1       4m 14s
@@ -80,14 +78,12 @@ The offset here denotes the last seen offset for the given consumer in the given
 
 Let's add another record to the topic:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ echo "Three" | fluvio produce hello-topic
 ```
 and read the topic again from the beginning for the same consumer:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio consume hello-topic -c c1 -Bd
 Consuming records from 'hello-topic' starting from the beginning of log
 Three
@@ -95,8 +91,7 @@ Three
 we get only one "unseen" record which is correct.
 Now if you try another consumer `c2`, you get all the records:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio consume hello-topic -c c2 -Bd
 Consuming records from 'hello-topic' starting from the beginning of log
 One
@@ -106,8 +101,7 @@ Three
 
 The consumer list now shows us two consumers:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio consumer list
   CONSUMER  TOPIC        PARTITION  OFFSET  LAST SEEN
   c1        hello-topic  0          2       3m 51s
@@ -116,8 +110,7 @@ $ fluvio consumer list
 
 We can delete them now:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio consumer delete c1
 consumer "c1" on topic "hello-topic" and partition "0" deleted
 $ fluvio consumer delete c2

--- a/docs/fluvio/how-to/install-cli-toolchain.mdx
+++ b/docs/fluvio/how-to/install-cli-toolchain.mdx
@@ -13,8 +13,7 @@ The `fvm` CLI is the official package manager for Fluvio, managing various `fluv
 
 The following command will install `fvm` and `fluvio` and other binaries in the development kit.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ curl -fsS https://hub.infinyon.cloud/install/install.sh | bash
 ```
 
@@ -22,8 +21,7 @@ The installation script prints a command that adds the the `fluvio` binaries to 
 
 On macOS, run this command and then close and reopen your terminal.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ echo 'export PATH="${HOME}/.fvm/bin:${HOME}/.fluvio/bin:${PATH}"' >> ~/.zshrc
 ```
 
@@ -40,8 +38,7 @@ If you have an existing `fluvio` installation (version `0.10.15` or older), you 
 #### Option 1: Delete the fluvio directory
 This will clear out your existing settings.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ rm -ri $HOME/.fluvio
 rm -ri $HOME/.fluvio
 examine files in directory $HOME/.fluvio? y
@@ -70,8 +67,7 @@ done: Now using fluvio version 0.10.16
 
 Running `fvm current` should display the most recent version of `fluvio` toolchain installed. (The most recent version is `0.10.16` for the purposes of this tutorial)
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fvm current
 0.10.16 (stable)
 ```
@@ -94,8 +90,7 @@ The `stable` channel is installed by default. It is the most recent supported re
 
 The following commands are equivalent for installing or updating the `stable` release channel.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fvm install
 $ fvm install stable
 ```
@@ -108,8 +103,7 @@ This channel consists of most recent updates that have not yet been released, wh
 
 The `latest` channel is not intended for typical usage.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fvm install latest
 info: Downloading (1/5): fluvio@0.11.0-dev-1+bf4e86674ce546d6b853adbf36a97e8e3344bd17
 info: Downloading (2/5): fluvio-run@0.11.0-dev-1+bf4e86674ce546d6b853adbf36a97e8e3344bd17
@@ -139,8 +133,7 @@ done: Now using fluvio version 0.10.16
 
 The `fvm show` command will list out the installed channels and their corresponding version. The row with the checkmark (`✓`) is the current active channel.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fvm show
     CHANNEL  VERSION
  ✓  0.10.16  0.10.16
@@ -154,8 +147,7 @@ If you are on another channel, you can change between them by running `fvm switc
 
 For typical usage of InfinyOn Cloud, we suggest using `stable`.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fvm switch stable
 
 done: Now using Fluvio version stable
@@ -163,8 +155,7 @@ done: Now using Fluvio version stable
 
 And we verify with `fvm show` that we are now back on the `stable` release channel.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fvm show
     CHANNEL  VERSION
  ✓  stable   0.10.16

--- a/docs/fluvio/how-to/smartmodule-basics.mdx
+++ b/docs/fluvio/how-to/smartmodule-basics.mdx
@@ -13,8 +13,7 @@ SmartModules are the basic building blocks for transformations in Fluvio, allowi
 
 ## See list of available SmartModules
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio hub sm list
   SMARTMODULE                              Visibility
   infinyon-labs/array-map-json@0.1.0       public
@@ -34,8 +33,7 @@ $ fluvio hub sm list
 SmartModules must be downloaded before they can be used. Afterwards, downloaded SmartModules are available for your Producers and Consumers.
 
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio hub sm download infinyon/regex-filter@0.1.0
 downloading infinyon/regex-filter@0.1.0 to infinyon-regex-filter-0.1.0.ipkg
 ... downloading complete
@@ -50,8 +48,7 @@ You can specify a SmartModule to use with `fluvio produce` and `fluvio consume`
 
 This consumer is using the SmartModule we just downloaded with `--smartmodule`, and is also configuring it with `--params`/`-e`.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio consume --smartmodule infinyon/regex-filter@0.1.0 --params regex='[Cc]at' cat-facts
 ```
 
@@ -60,8 +57,7 @@ You can configure SmartModules with multiple parameters by passing multiple `--p
 
 e.g.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio produce --smartmodule example/my-smartmodule@0.1.0 -e name=example -e point_made=true
 ```
 </Idea>
@@ -85,15 +81,13 @@ transforms:
       regex: "[Cc]at"
 ```
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio consume --transforms-file ./my-transforms.yaml my-topic
 ```
 
 ## See list of Downloaded SmartModules
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio sm list
   SMARTMODULE                  SIZE
   infinyon/jolt@0.3.0          611.5 KB
@@ -105,8 +99,7 @@ $ fluvio sm list
 
 ## Delete SmartModules
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio sm delete infinyon/json-sql@0.2.1
 smartmodule "infinyon/json-sql@0.2.1" deleted
 ```
@@ -147,8 +140,7 @@ transforms:
 
 Everything is in the config file. You create a connector as usual.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio cloud connector create --config connector-example.yaml
 ```
 
@@ -176,8 +168,7 @@ webhook:
 
 Just like Connectors, everything is in the config file. You create a webhook as usual.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 fluvio cloud webhook create --config example-webhook.yaml
 ```
 

--- a/docs/fluvio/how-to/use-connectors-in-cloud.mdx
+++ b/docs/fluvio/how-to/use-connectors-in-cloud.mdx
@@ -50,8 +50,7 @@ In this config, we are creating a connector named `cat-facts`. It will request d
 
 You can create a connector by using `fluvio cloud connector create` with the example connector.
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio cloud connector create --config catfacts-basic-connector.yml
 connector "cat-facts" (http-source) created
 ```
@@ -59,8 +58,7 @@ connector "cat-facts" (http-source) created
 
 After the connector is created, you can list the connectors you've created, and view their current status.
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio cloud connector list
  NAME       TYPE         VERSION  CDK  STATUS
  cat-facts  http-source  0.1.0    V3   Running
@@ -70,8 +68,7 @@ $ fluvio cloud connector list
 
 If there is a need to debug the behavior of a connector, the logs are available by running `fluvio cloud connector logs cat-facts`
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio cloud connector logs cat-facts
 connector-startup infinyon/http-source@0.1.0
 2023-03-25T03:41:29.570294Z  INFO surf::middleware::logger::native: sending request
@@ -101,8 +98,7 @@ Connector runs with process id: 15
 
 The HTTP connector should be receiving data and storing it in a topic with the name we specified.
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio topic list
   NAME            TYPE      PARTITIONS  REPLICAS  RETENTION TIME  COMPRESSION  STATUS                   REASON
   cat-facts-data  computed  1           1         7days           any          resolution::provisioned
@@ -128,16 +124,14 @@ $ fluvio consume cat-facts-data -B
 
 When you want to stop the connector, you can delete it with `fluvio cloud connector cat-facts`
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio cloud connector delete cat-facts
 connector "cat-facts" deleted
 ```
 
 Deleting your connector will not delete the topic used by the connector. If you want to delete the topic, you can run `fluvio topic delete cat-facts`
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio topic delete cat-facts
 topic "cat-facts" deleted
 ```

--- a/docs/fluvio/how-to/use-connectors.mdx
+++ b/docs/fluvio/how-to/use-connectors.mdx
@@ -19,8 +19,7 @@ This guide demonstrates creating an Inbound HTTP connector to ingest JSON data f
 
 Sign up for [InfinyOn Cloud] and log into the CLI to begin:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio cloud login
 ```
 
@@ -48,8 +47,7 @@ In this configuration, a connector named `cat-facts` is created. It requests dat
 
 Create a connector using the following command:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio cloud connector create --config catfacts-basic-connector.yml
 connector "cat-facts" (http-source) created
 ```
@@ -58,8 +56,7 @@ connector "cat-facts" (http-source) created
 
 Once created, list the connectors and view their current status:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio cloud connector list
  NAME       TYPE         VERSION  CDK  STATUS
  cat-facts  http-source  0.1.0    V3   Running
@@ -69,8 +66,7 @@ $ fluvio cloud connector list
 
 Debug connector behavior by accessing the logs:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio cloud connector logs cat-facts
 connector-startup infinyon/http-source@0.1.0
 2023-03-25T03:41:29.570294Z  INFO surf::middleware::logger::native: sending request
@@ -100,8 +96,7 @@ Connector runs with process id: 15
 
 The HTTP connector should now be storing data in the specified topic:
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio topic list
   NAME            TYPE      PARTITIONS  REPLICAS  RETENTION TIME  COMPRESSION  STATUS                   REASON
   cat-facts-data  computed  1           1         7days           any          resolution::provisioned
@@ -109,8 +104,7 @@ $ fluvio topic list
 
 Verify by consuming from the topic:
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio consume cat-facts-data -B
 {"fact":"Female felines are \\superfecund","length":31}
 {"fact":"Cats only sweat through their paws and nowhere else on their body","length":65}
@@ -126,16 +120,14 @@ The `--disable-continuous` flag exits the stream after displaying the last recor
 
 To stop the connector, delete it:
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio cloud connector delete cat-facts
 connector "cat-facts" deleted
 ```
 
 This action won’t delete the topic. Delete it separately if needed:
 
-%copy first-line%
-```shell
+```shell copy="fl"
 $ fluvio topic delete cat-facts
 topic "cat-facts" deleted
 ```

--- a/docs/fluvio/references/cli/produce.mdx
+++ b/docs/fluvio/references/cli/produce.mdx
@@ -17,7 +17,6 @@ Produce records by specifying the destination Topic
 The quickest way to send a record using the producer is to just type your record
 into standard input:
 
-%copy first-line%
 ```bash
 $ fluvio produce my-topic
 > This is my first record ever

--- a/docs/fluvio/references/cli/version.mdx
+++ b/docs/fluvio/references/cli/version.mdx
@@ -8,7 +8,7 @@ slug: /cli/version
 The `fluvio version` command prints out build information about the the
 `fluvio` binary and any plugin extensions
 
-```bash
+```bash title="connector-example.yaml" copy="fl"
 fluvio version
  Fluvio CLI                     : 0.11.8
  Fluvio CLI Arch                : aarch64-apple-darwin

--- a/docs/fluvio/references/smartmodules/transform/filter.mdx
+++ b/docs/fluvio/references/smartmodules/transform/filter.mdx
@@ -246,8 +246,7 @@ $ fluvio produce server-logs -f server.log
 
 Let's double check it's all there.
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio consume server-logs -B -d
 {"level":"info","message":"Server listening on 0.0.0.0:8000"}
 {"level":"info","message":"Accepted incoming connection"}
@@ -266,8 +265,7 @@ $ fluvio consume server-logs -B -d
 
 The SmartModule can be loaded to local Fluvio Cluster or [InfinyOn Cloud], as determined by the [`current profile`]. In this example, the profile points to InfinyOn Cloud.
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ smdk load
 Loading package at: ~/smdk/json-filter
 Found SmartModule package: json-filter
@@ -278,8 +276,7 @@ Creating SmartModule: json-filter
 
 Rust `fluvio smartmodule list` to ensure your SmartModule has been uploaded:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio smartmodule list
   SMARTMODULE                   SIZE
   john/json-filter@0.1.0        140.1 KB
@@ -287,8 +284,7 @@ $ fluvio smartmodule list
 
 SmartModules that have been uploaded on the cluster can be used by other areas of the system (consumers, producers, connectors, etc):
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio consume server-logs -dB --smartmodule=john/json-filter@0.1.0
 Consuming records from the beginning of topic 'server-logs'
 {"level":"info","message":"Server listening on 0.0.0.0:8000"}
@@ -305,8 +301,7 @@ Congratulations! :tada: Eveything worked as expected!
 
 It turns out this SmartModule was requested by other data streaming teams in the organization, so we've decided to [publish] it on [SmartModule Hub].
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ smdk publish
 Creating package john/json-filter@0.1.0
 .. fill out info in hub/package-meta.yaml
@@ -316,8 +311,7 @@ Package uploaded!
 
 Let's double check that the SmartModule is available for download:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio hub list
   SMARTMODULE                 Visibility
   john/json-filter@0.1.0      private

--- a/docs/fluvio/references/smartmodules/transform/map.mdx
+++ b/docs/fluvio/references/smartmodules/transform/map.mdx
@@ -21,8 +21,7 @@ example looks like.
 
 Run `smdk generate` with the name of the map and choose the "map" options:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ smdk generate map-example
 Generating new SmartModule project: map-example
 project-group => 'john'
@@ -45,8 +44,7 @@ Ignoring: /var/folders/5q/jwc86771549058kmbkbqjcdc0000gn/T/.tmpNFObJj/cargo-gene
 
 We should see a new folder has been created for our project `map-example`. Let's navigate inside and take a look at the sample Map generated for us by the template:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ cd map-example && cat ./src/lib.rs
 ```
 
@@ -85,8 +83,7 @@ This template SmartModule will parse each record as an `i32` integer, then multi
 
 Let's make sure our code compiles. If eveything works as expected, there will be a `.wasm` file generated in the target directory.
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ smdk build
 ...
 Compiling map-example v0.1.0 (~/smdk/map-example)
@@ -99,8 +96,7 @@ Your WASM binary is now ready for use.
 
 Now that we've written our map, let's test using the command line.
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ smdk test --text=6
 loading module at: ~/smdk/map-example/target/wasm32-unknown-unknown/release-lto/map_example.wasm
 1 records outputed
@@ -114,16 +110,14 @@ Good news! :tada: it works as expected!
 
 Let's create a new topic to produce our source data:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio topic create map-double
 topic "map-double" created
 ```
 
 In a new terminal, producde the following entries:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio produce map-double
 > 1
 Ok!
@@ -140,8 +134,7 @@ Ok!
 
 Let's double check it's all there.
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio consume map-double -B -d
 Consuming records from the beginning of topic 'map-double'
 1
@@ -155,8 +148,7 @@ Consuming records from the beginning of topic 'map-double'
 
 The SmartModule can be loaded to local Fluvio Cluster or [InfinyOn Cloud], as determined by the [`current profile`]. In this example, the profile points to InfinyOn Cloud.
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ smdk load
 Loading package at: ~/smdk/map-example
 Found SmartModule package: map-example
@@ -167,8 +159,7 @@ Creating SmartModule: map-example
 
 Rust `fluvio smartmodule list` to ensure your SmartModule has been uploaded:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio smartmodule list
  SMARTMODULE                    SIZE
  john/map-example@0.1.0         87.5 KB
@@ -176,8 +167,7 @@ $ fluvio smartmodule list
 
 SmartModules that have been uploaded on the cluster can be used by other areas of the system (consumers, producers, connectors, etc):
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio consume map-double -B --smartmodule=john/map-example@0.1.0
 Consuming records from the beginning of topic 'map-double'
 2
@@ -194,8 +184,7 @@ Congratulations! :tada: Eveything worked as expected!
 
 As bonus, let's [publish] this SmartModule to [SmartModule Hub].
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ smdk publish
 Creating package john/map-example@0.1.0
 .. fill out info in hub/package-meta.yaml
@@ -205,8 +194,7 @@ Package uploaded!
 
 Let's double check that the SmartModule is available for download:
 
-%copy first-line%
-```bash
+```bash copy="fl"
 $ fluvio hub list
   SMARTMODULE                 Visibility
   john/map-exampler@0.1.0      private

--- a/src/theme/CodeBlock/Container/index.tsx
+++ b/src/theme/CodeBlock/Container/index.tsx
@@ -1,0 +1,25 @@
+import React, {type ComponentProps} from 'react';
+import clsx from 'clsx';
+import {ThemeClassNames, usePrismTheme} from '@docusaurus/theme-common';
+import {getPrismCssVariables} from '@docusaurus/theme-common/internal';
+import styles from './styles.module.css';
+
+export default function CodeBlockContainer<T extends 'div' | 'pre'>({
+  as: As,
+  ...props
+}: {as: T} & ComponentProps<T>): JSX.Element {
+  const prismTheme = usePrismTheme();
+  const prismCssVariables = getPrismCssVariables(prismTheme);
+  return (
+    <As
+      // Polymorphic components are hard to type, without `oneOf` generics
+      {...(props as any)}
+      style={prismCssVariables}
+      className={clsx(
+        props.className,
+        styles.codeBlockContainer,
+        ThemeClassNames.common.codeBlock,
+      )}
+    />
+  );
+}

--- a/src/theme/CodeBlock/Container/styles.module.css
+++ b/src/theme/CodeBlock/Container/styles.module.css
@@ -1,0 +1,7 @@
+.codeBlockContainer {
+  background: var(--prism-background-color);
+  color: var(--prism-color);
+  margin-bottom: var(--ifm-leading);
+  box-shadow: var(--ifm-global-shadow-lw);
+  border-radius: var(--ifm-code-border-radius);
+}

--- a/src/theme/CodeBlock/Content/Element.tsx
+++ b/src/theme/CodeBlock/Content/Element.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import clsx from 'clsx';
+import Container from '@theme/CodeBlock/Container';
+import type {Props} from '@theme/CodeBlock/Content/Element';
+
+import styles from './styles.module.css';
+
+// <pre> tags in markdown map to CodeBlocks. They may contain JSX children. When
+// the children is not a simple string, we just return a styled block without
+// actually highlighting.
+export default function CodeBlockJSX({
+  children,
+  className,
+}: Props & {
+  copyBehavior: string;
+}): JSX.Element {
+  return (
+    <Container
+      as="pre"
+      tabIndex={0}
+      className={clsx(styles.codeBlockStandalone, 'thin-scrollbar', className)}>
+      <code className={styles.codeBlockLines}>{children}</code>
+    </Container>
+  );
+}

--- a/src/theme/CodeBlock/Content/String.tsx
+++ b/src/theme/CodeBlock/Content/String.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import clsx from 'clsx';
+import {useThemeConfig, usePrismTheme} from '@docusaurus/theme-common';
+import {
+  parseCodeBlockTitle,
+  parseLanguage,
+  parseLines,
+  containsLineNumbers,
+  useCodeWordWrap,
+} from '@docusaurus/theme-common/internal';
+import {Highlight, type Language} from 'prism-react-renderer';
+import Line from '@theme/CodeBlock/Line';
+import CopyButton from '@theme/CodeBlock/CopyButton';
+import WordWrapButton from '@theme/CodeBlock/WordWrapButton';
+import Container from '@theme/CodeBlock/Container';
+import type {Props} from '@theme/CodeBlock/Content/String';
+
+import styles from './styles.module.css';
+
+// Prism languages are always lowercase
+// We want to fail-safe and allow both "php" and "PHP"
+// See https://github.com/facebook/docusaurus/issues/9012
+function normalizeLanguage(language: string | undefined): string | undefined {
+  return language?.toLowerCase();
+}
+
+export default function CodeBlockString({
+  children,
+  className: blockClassName = '',
+  metastring,
+  title: titleProp,
+  copyBehavior,
+  showLineNumbers: showLineNumbersProp,
+  language: languageProp,
+}: Props & {
+  copyBehavior: string;
+}): JSX.Element {
+  const {
+    prism: {defaultLanguage, magicComments},
+  } = useThemeConfig();
+  const language = normalizeLanguage(
+    languageProp ?? parseLanguage(blockClassName) ?? defaultLanguage,
+  );
+
+  const prismTheme = usePrismTheme();
+  const wordWrap = useCodeWordWrap();
+
+  // We still parse the metastring in case we want to support more syntax in the
+  // future. Note that MDX doesn't strip quotes when parsing metastring:
+  // "title=\"xyz\"" => title: "\"xyz\""
+  const title = parseCodeBlockTitle(metastring) || titleProp;
+
+  const {lineClassNames, code} = parseLines(children, {
+    metastring,
+    language,
+    magicComments,
+  });
+  const showLineNumbers =
+    showLineNumbersProp ?? containsLineNumbers(metastring);
+
+  return (
+    <Container
+      as="div"
+      className={clsx(
+        blockClassName,
+        language &&
+          !blockClassName.includes(`language-${language}`) &&
+          `language-${language}`,
+      )}>
+      {title && <div className={styles.codeBlockTitle}>{title}</div>}
+      <div className={styles.codeBlockContent}>
+        <Highlight
+          theme={prismTheme}
+          code={code}
+          language={(language ?? 'text') as Language}>
+          {({className, style, tokens, getLineProps, getTokenProps}) => (
+            <pre
+              /* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */
+              tabIndex={0}
+              ref={wordWrap.codeBlockRef}
+              className={clsx(className, styles.codeBlock, 'thin-scrollbar')}
+              style={style}>
+              <code
+                className={clsx(
+                  styles.codeBlockLines,
+                  showLineNumbers && styles.codeBlockLinesWithNumbering,
+                )}>
+                {tokens.map((line, i) => (
+                  <Line
+                    key={i}
+                    line={line}
+                    getLineProps={getLineProps}
+                    getTokenProps={getTokenProps}
+                    classNames={lineClassNames[i]}
+                    showLineNumbers={showLineNumbers}
+                  />
+                ))}
+              </code>
+            </pre>
+          )}
+        </Highlight>
+        <div className={styles.buttonGroup}>
+          {(wordWrap.isEnabled || wordWrap.isCodeScrollable) && (
+            <WordWrapButton
+              className={styles.codeButton}
+              onClick={() => wordWrap.toggle()}
+              isEnabled={wordWrap.isEnabled}
+            />
+          )}
+          <CopyButton className={styles.codeButton} code={code} copyBehavior={copyBehavior} />
+        </div>
+      </div>
+    </Container>
+  );
+}

--- a/src/theme/CodeBlock/Content/styles.module.css
+++ b/src/theme/CodeBlock/Content/styles.module.css
@@ -1,0 +1,80 @@
+.codeBlockContent {
+  position: relative;
+  /* rtl:ignore */
+  direction: ltr;
+  border-radius: inherit;
+}
+
+.codeBlockTitle {
+  border-bottom: 1px solid var(--ifm-color-emphasis-300);
+  font-size: var(--ifm-code-font-size);
+  font-weight: 500;
+  padding: 0.75rem var(--ifm-pre-padding);
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
+}
+
+.codeBlock {
+  --ifm-pre-background: var(--prism-background-color);
+  margin: 0;
+  padding: 0;
+}
+
+.codeBlockTitle + .codeBlockContent .codeBlock {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.codeBlockStandalone {
+  padding: 0;
+}
+
+.codeBlockLines {
+  font: inherit;
+  /* rtl:ignore */
+  float: left;
+  min-width: 100%;
+  padding: var(--ifm-pre-padding);
+}
+
+.codeBlockLinesWithNumbering {
+  display: table;
+  padding: var(--ifm-pre-padding) 0;
+}
+
+@media print {
+  .codeBlockLines {
+    white-space: pre-wrap;
+  }
+}
+
+.buttonGroup {
+  display: flex;
+  column-gap: 0.2rem;
+  position: absolute;
+  /* rtl:ignore */
+  right: calc(var(--ifm-pre-padding) / 2);
+  top: calc(var(--ifm-pre-padding) / 2);
+}
+
+.buttonGroup button {
+  display: flex;
+  align-items: center;
+  background: var(--prism-background-color);
+  color: var(--prism-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  padding: 0.4rem;
+  line-height: 0;
+  transition: opacity var(--ifm-transition-fast) ease-in-out;
+  opacity: 0;
+}
+
+.buttonGroup button:focus-visible,
+.buttonGroup button:hover {
+  opacity: 1 !important;
+}
+
+:global(.theme-code-block:hover) .buttonGroup button {
+  opacity: 0.4;
+}

--- a/src/theme/CodeBlock/CopyButton/index.tsx
+++ b/src/theme/CodeBlock/CopyButton/index.tsx
@@ -1,0 +1,97 @@
+import React, {useCallback, useState, useRef, useEffect} from 'react';
+import clsx from 'clsx';
+import copy from 'copy-text-to-clipboard';
+import {translate} from '@docusaurus/Translate';
+import type {Props} from '@theme/CodeBlock/CopyButton';
+import IconCopy from '@theme/Icon/Copy';
+import IconSuccess from '@theme/Icon/Success';
+
+import styles from './styles.module.css';
+
+const CODE_BLOCK_COPY_REGEXP = /copy=(?<quote>["'])(?<copy>.*?)\1/;
+
+export enum CopyBehavior {
+  FirstLine = 'fl',
+  FullText = 'full',
+}
+
+const COPY_BEHAVIOR = Object.values(CopyBehavior);
+
+export function parseCodeBlockCopy(metastring?: string): CopyBehavior {
+  const copy = metastring?.match(CODE_BLOCK_COPY_REGEXP)?.groups!.copy?.trim();
+
+  if (!copy) {
+    // Fallback to Full Text
+    return CopyBehavior.FullText;
+  }
+
+  const match = COPY_BEHAVIOR.find((cb) => cb === copy) as CopyBehavior | undefined;
+
+  if (match) {
+    return match;
+  }
+
+  throw new Error(`Invalid copy behavior: ${copy}. Valid values are: ${COPY_BEHAVIOR.join(', ')}`);
+}
+
+function textWithCopyBehavior(text: string, cb: CopyBehavior): string {
+  switch(cb) {
+    case CopyBehavior.FirstLine:
+      return text.split('\n')[0];
+    default:
+      return text;
+  }
+}
+
+export default function CopyButton({code, className, copyBehavior}: Props & {
+  copyBehavior: CopyBehavior;
+}): JSX.Element {
+  const [isCopied, setIsCopied] = useState(false);
+  const copyTimeout = useRef<number | undefined>(undefined);
+  const handleCopyCode = useCallback(() => {
+    const text = textWithCopyBehavior(code, copyBehavior);
+
+    copy(text);
+    setIsCopied(true);
+    copyTimeout.current = window.setTimeout(() => {
+      setIsCopied(false);
+    }, 1000);
+  }, [code]);
+
+  useEffect(() => () => window.clearTimeout(copyTimeout.current), []);
+
+  return (
+    <button
+      type="button"
+      aria-label={
+        isCopied
+          ? translate({
+              id: 'theme.CodeBlock.copied',
+              message: 'Copied',
+              description: 'The copied button label on code blocks',
+            })
+          : translate({
+              id: 'theme.CodeBlock.copyButtonAriaLabel',
+              message: 'Copy code to clipboard',
+              description: 'The ARIA label for copy code blocks button',
+            })
+      }
+      title={translate({
+        id: 'theme.CodeBlock.copy',
+        message: 'Copy',
+        description: 'The copy button label on code blocks',
+      })}
+      className={clsx(
+        'clean-btn',
+        className,
+        styles.copyButton,
+        isCopied && styles.copyButtonCopied,
+      )}
+      onClick={handleCopyCode}>
+      <span className={styles.copyButtonIcons} aria-hidden="true">
+        <IconCopy className={styles.copyButtonIcon} />
+        <IconSuccess className={styles.copyButtonSuccessIcon} />
+      </span>
+    </button>
+  );
+}

--- a/src/theme/CodeBlock/CopyButton/styles.module.css
+++ b/src/theme/CodeBlock/CopyButton/styles.module.css
@@ -1,0 +1,40 @@
+:global(.theme-code-block:hover) .copyButtonCopied {
+  opacity: 1 !important;
+}
+
+.copyButtonIcons {
+  position: relative;
+  width: 1.125rem;
+  height: 1.125rem;
+}
+
+.copyButtonIcon,
+.copyButtonSuccessIcon {
+  position: absolute;
+  top: 0;
+  left: 0;
+  fill: currentColor;
+  opacity: inherit;
+  width: inherit;
+  height: inherit;
+  transition: all var(--ifm-transition-fast) ease;
+}
+
+.copyButtonSuccessIcon {
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.33);
+  opacity: 0;
+  color: #00d600;
+}
+
+.copyButtonCopied .copyButtonIcon {
+  transform: scale(0.33);
+  opacity: 0;
+}
+
+.copyButtonCopied .copyButtonSuccessIcon {
+  transform: translate(-50%, -50%) scale(1);
+  opacity: 1;
+  transition-delay: 0.075s;
+}

--- a/src/theme/CodeBlock/Line/index.tsx
+++ b/src/theme/CodeBlock/Line/index.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import clsx from 'clsx';
+import type {Props} from '@theme/CodeBlock/Line';
+
+import styles from './styles.module.css';
+
+export default function CodeBlockLine({
+  line,
+  classNames,
+  showLineNumbers,
+  getLineProps,
+  getTokenProps,
+}: Props): JSX.Element {
+  if (line.length === 1 && line[0]!.content === '\n') {
+    line[0]!.content = '';
+  }
+
+  const lineProps = getLineProps({
+    line,
+    className: clsx(classNames, showLineNumbers && styles.codeLine),
+  });
+
+  const lineTokens = line.map((token, key) => (
+    <span key={key} {...getTokenProps({token})} />
+  ));
+
+  return (
+    <span {...lineProps}>
+      {showLineNumbers ? (
+        <>
+          <span className={styles.codeLineNumber} />
+          <span className={styles.codeLineContent}>{lineTokens}</span>
+        </>
+      ) : (
+        lineTokens
+      )}
+      <br />
+    </span>
+  );
+}

--- a/src/theme/CodeBlock/Line/styles.module.css
+++ b/src/theme/CodeBlock/Line/styles.module.css
@@ -1,0 +1,45 @@
+/* Intentionally has zero specificity, so that to be able to override
+the background in custom CSS file due bug https://github.com/facebook/docusaurus/issues/3678 */
+:where(:root) {
+  --docusaurus-highlighted-code-line-bg: rgb(72 77 91);
+}
+
+:where([data-theme='dark']) {
+  --docusaurus-highlighted-code-line-bg: rgb(100 100 100);
+}
+
+:global(.theme-code-block-highlighted-line) {
+  background-color: var(--docusaurus-highlighted-code-line-bg);
+  display: block;
+  margin: 0 calc(-1 * var(--ifm-pre-padding));
+  padding: 0 var(--ifm-pre-padding);
+}
+
+.codeLine {
+  display: table-row;
+  counter-increment: line-count;
+}
+
+.codeLineNumber {
+  display: table-cell;
+  text-align: right;
+  width: 1%;
+  position: sticky;
+  left: 0;
+  padding: 0 var(--ifm-pre-padding);
+  background: var(--ifm-pre-background);
+  overflow-wrap: normal;
+}
+
+.codeLineNumber::before {
+  content: counter(line-count);
+  opacity: 0.4;
+}
+
+:global(.theme-code-block-highlighted-line) .codeLineNumber::before {
+  opacity: 0.8;
+}
+
+.codeLineContent {
+  padding-right: var(--ifm-pre-padding);
+}

--- a/src/theme/CodeBlock/WordWrapButton/index.tsx
+++ b/src/theme/CodeBlock/WordWrapButton/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import type {Props} from '@theme/CodeBlock/WordWrapButton';
+import IconWordWrap from '@theme/Icon/WordWrap';
+
+import styles from './styles.module.css';
+
+export default function WordWrapButton({
+  className,
+  onClick,
+  isEnabled,
+}: Props): JSX.Element | null {
+  const title = translate({
+    id: 'theme.CodeBlock.wordWrapToggle',
+    message: 'Toggle word wrap',
+    description:
+      'The title attribute for toggle word wrapping button of code block lines',
+  });
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={clsx(
+        'clean-btn',
+        className,
+        isEnabled && styles.wordWrapButtonEnabled,
+      )}
+      aria-label={title}
+      title={title}>
+      <IconWordWrap className={styles.wordWrapButtonIcon} aria-hidden="true" />
+    </button>
+  );
+}

--- a/src/theme/CodeBlock/WordWrapButton/styles.module.css
+++ b/src/theme/CodeBlock/WordWrapButton/styles.module.css
@@ -1,0 +1,8 @@
+.wordWrapButtonIcon {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+
+.wordWrapButtonEnabled .wordWrapButtonIcon {
+  color: var(--ifm-color-primary);
+}

--- a/src/theme/CodeBlock/index.tsx
+++ b/src/theme/CodeBlock/index.tsx
@@ -1,0 +1,42 @@
+import React, {isValidElement, type ReactNode} from 'react';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import ElementContent from '@theme/CodeBlock/Content/Element';
+import StringContent from '@theme/CodeBlock/Content/String';
+
+import { parseCodeBlockCopy } from './CopyButton';
+
+import type {Props} from '@theme/CodeBlock';
+
+/**
+ * Best attempt to make the children a plain string so it is copyable. If there
+ * are react elements, we will not be able to copy the content, and it will
+ * return `children` as-is; otherwise, it concatenates the string children
+ * together.
+ */
+function maybeStringifyChildren(children: ReactNode): ReactNode {
+  if (React.Children.toArray(children).some((el) => isValidElement(el))) {
+    return children;
+  }
+  // The children is now guaranteed to be one/more plain strings
+  return Array.isArray(children) ? children.join('') : (children as string);
+}
+
+export default function CodeBlock({
+  children: rawChildren,
+  metastring
+}: Props): JSX.Element {
+  // The Prism theme on SSR is always the default theme but the site theme can
+  // be in a different mode. React hydration doesn't update DOM styles that come
+  // from SSR. Hence force a re-render after mounting to apply the current
+  // relevant styles.
+  const copy = parseCodeBlockCopy(metastring);
+  const isBrowser = useIsBrowser();
+  const children = maybeStringifyChildren(rawChildren);
+  const CodeBlockComp =
+    typeof children === 'string' ? StringContent : ElementContent;
+  return (
+    <CodeBlockComp key={String(isBrowser)} copyBehavior={copy}>
+      {children as string}
+    </CodeBlockComp>
+  );
+}


### PR DESCRIPTION
Provides support for `copy="fl"` a meta string on each code snippet that allow us to set
the copy to clipboard behavior.

For some snippets only the first line is relevant when copying the text to the clipboard.

In order to use it we must provide the following:

```diff
- %copy first-line%
- ```bash
+ ```bash copy="fl"
```

When `copy="fl"` is not present, then full text copy is performed as default.