### PR TITLE
feat: google analytics support

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -78,9 +78,9 @@ const config: Config = {
       },
     ],
     [
-      '@docusaurus/plugin-google-gtag',
+      "@docusaurus/plugin-google-gtag",
       {
-        trackingID: 'G-R7V7KJ5G2Z',
+        trackingID: "G-R7V7KJ5G2Z",
         anonymizeIP: true,
       },
     ],
@@ -152,7 +152,7 @@ const config: Config = {
         {
           position: "left",
           label: "SDF",
-          to: '/sdf',
+          to: "/sdf",
         },
         {
           type: "doc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "fluvio-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "^3.4.0",
-        "@docusaurus/plugin-content-blog": "^3.4.0",
-        "@docusaurus/plugin-google-gtag": "^3.5.0",
-        "@docusaurus/preset-classic": "^3.4.0",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/plugin-content-blog": "3.4.0",
+        "@docusaurus/plugin-google-gtag": "3.4.0",
+        "@docusaurus/preset-classic": "3.4.0",
         "@easyops-cn/docusaurus-search-local": "^0.44.4",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
@@ -20,9 +20,9 @@
         "react-dom": "^18.0.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.4.0",
-        "@docusaurus/tsconfig": "^3.4.0",
-        "@docusaurus/types": "^3.4.0",
+        "@docusaurus/module-type-aliases": "3.4.0",
+        "@docusaurus/tsconfig": "3.4.0",
+        "@docusaurus/types": "3.4.0",
         "autoprefixer": "^10.4.19",
         "postcss": "^8.4.38",
         "postcss-import": "^16.1.0",
@@ -2442,13 +2442,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.5.0.tgz",
-      "integrity": "sha512-a8ABEXLtG27Mm4u9F4nvh/f6oEONRISzvikORPToobSogsf1E6AGVkRrWwEnMr4M8uqj+jTtrB2NbNMdvAOGMQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.4.0.tgz",
+      "integrity": "sha512-Dsgg6PLAqzZw5wZ4QjUYc8Z2KqJqXxHxq3vIoyoBWiLEEfigIs7wHR+oiWUQy3Zk9MIk6JTYj7tMoQU0Jm3nqA==",
       "dependencies": {
-        "@docusaurus/core": "3.5.0",
-        "@docusaurus/types": "3.5.0",
-        "@docusaurus/utils-validation": "3.5.0",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -2458,250 +2458,6 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/core": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.5.0.tgz",
-      "integrity": "sha512-B3xQMwHc+NwLWuHfwdpXTpu3iZoEYNMhSzE6IsxIjCUAjQO01nwLp99M3aiaVkL4xXoZlc1Hhlc6eB8a3SsRtw==",
-      "dependencies": {
-        "@babel/core": "^7.23.3",
-        "@babel/generator": "^7.23.3",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.22.9",
-        "@babel/preset-env": "^7.22.9",
-        "@babel/preset-react": "^7.22.5",
-        "@babel/preset-typescript": "^7.22.5",
-        "@babel/runtime": "^7.22.6",
-        "@babel/runtime-corejs3": "^7.22.6",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.5.0",
-        "@docusaurus/logger": "3.5.0",
-        "@docusaurus/mdx-loader": "3.5.0",
-        "@docusaurus/utils": "3.5.0",
-        "@docusaurus/utils-common": "3.5.0",
-        "@docusaurus/utils-validation": "3.5.0",
-        "autoprefixer": "^10.4.14",
-        "babel-loader": "^9.1.3",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.2",
-        "cli-table3": "^0.6.3",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.31.1",
-        "css-loader": "^6.8.1",
-        "css-minimizer-webpack-plugin": "^5.0.1",
-        "cssnano": "^6.1.2",
-        "del": "^6.1.1",
-        "detect-port": "^1.5.1",
-        "escape-html": "^1.0.3",
-        "eta": "^2.2.0",
-        "eval": "^0.1.8",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "html-minifier-terser": "^7.2.0",
-        "html-tags": "^3.3.1",
-        "html-webpack-plugin": "^5.5.3",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.7.6",
-        "p-map": "^4.0.0",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.4",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.4",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.5.4",
-        "serve-handler": "^6.1.5",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.9",
-        "tslib": "^2.6.0",
-        "update-notifier": "^6.0.2",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.1",
-        "webpack-bundle-analyzer": "^4.9.0",
-        "webpack-dev-server": "^4.15.1",
-        "webpack-merge": "^5.9.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.5.0.tgz",
-      "integrity": "sha512-BMurr8nS73M777HInIfbSmG2EogfEKZKw13s/bH1MArFoHTA+mdwIUIkGxwDP5orhsrDTpzbyPjXkHZtYyNWEg==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
-        "postcss-sort-media-queries": "^5.2.0",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/logger": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.5.0.tgz",
-      "integrity": "sha512-7ITYJjnogAEdNeB4ixQEdS1AdMBmD2IcPPLZuOs1sGtStBPBjl+yi/uLLGnqXO3x4atGNONrPSBNnfxynGUxMw==",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/mdx-loader": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.5.0.tgz",
-      "integrity": "sha512-9XWVtF+eCzvVBqyRqBqP2GhnNET/1Y/tLCVsyacr/nKl5DBXZTHYkGw7t1wAF8tfZsiICa+xdru5FJvD+GfcDg==",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.0",
-        "@docusaurus/utils": "3.5.0",
-        "@docusaurus/utils-validation": "3.5.0",
-        "@mdx-js/mdx": "^3.0.0",
-        "@slorber/remark-comment": "^1.0.0",
-        "escape-html": "^1.0.3",
-        "estree-util-value-to-estree": "^3.0.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
-        "mdast-util-mdx": "^3.0.0",
-        "mdast-util-to-string": "^4.0.0",
-        "rehype-raw": "^7.0.0",
-        "remark-directive": "^3.0.0",
-        "remark-emoji": "^4.0.0",
-        "remark-frontmatter": "^5.0.0",
-        "remark-gfm": "^4.0.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.6.0",
-        "unified": "^11.0.3",
-        "unist-util-visit": "^5.0.0",
-        "url-loader": "^4.1.1",
-        "vfile": "^6.0.1",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.5.0.tgz",
-      "integrity": "sha512-HRkpYBluSihIq98waEHGmmVNAZ2va1fShEE7ZGYkfL2kjCs84cSDF/blUZ+415h2+NEtebQb6vtKLNC0RZVGTg==",
-      "dependencies": {
-        "@mdx-js/mdx": "^3.0.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.9.2",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1",
-        "webpack-merge": "^5.9.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.5.0.tgz",
-      "integrity": "sha512-RknfD/Tztd3wYWHTdCIlzH4mZcwfeGA4F4qaHZei3XpXocvvsqNlr7fjWZU83Uad2ty4sgQL7cwYSDHQuCBCig==",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.0",
-        "@docusaurus/utils-common": "3.5.0",
-        "@svgr/webpack": "^8.1.0",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^11.1.1",
-        "github-slugger": "^1.5.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "jiti": "^1.20.0",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "prompts": "^2.4.2",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.6.0",
-        "url-loader": "^4.1.1",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.88.1"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils-common": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.5.0.tgz",
-      "integrity": "sha512-RyeqPhOfocQkh+ldDiwJBi0h9zZAhccqtzl+aECbgP1a7kdGFLUS0SgVjF1iYUk5RBW03DH+fevT6s4brCWspA==",
-      "dependencies": {
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils-validation": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.5.0.tgz",
-      "integrity": "sha512-ZWo75T0nv1oX1zx7Nv+woS0ReeONdaK+WddKyYy7M7DnnAe9M5uhRaEPlyDWl9KpXrRZ1piTWBBye79MCTFyTA==",
-      "dependencies": {
-        "@docusaurus/logger": "3.5.0",
-        "@docusaurus/utils": "3.5.0",
-        "@docusaurus/utils-common": "3.5.0",
-        "fs-extra": "^11.2.0",
-        "joi": "^17.9.2",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=18.0"
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
@@ -2763,25 +2519,6 @@
         "@docusaurus/theme-common": "3.4.0",
         "@docusaurus/theme-search-algolia": "3.4.0",
         "@docusaurus/types": "3.4.0"
-      },
-      "engines": {
-        "node": ">=18.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.4.0.tgz",
-      "integrity": "sha512-Dsgg6PLAqzZw5wZ4QjUYc8Z2KqJqXxHxq3vIoyoBWiLEEfigIs7wHR+oiWUQy3Zk9MIk6JTYj7tMoQU0Jm3nqA==",
-      "dependencies": {
-        "@docusaurus/core": "3.4.0",
-        "@docusaurus/types": "3.4.0",
-        "@docusaurus/utils-validation": "3.4.0",
-        "@types/gtag.js": "^0.0.12",
-        "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=18.0"

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.4.0",
-    "@docusaurus/plugin-content-blog": "^3.4.0",
-    "@docusaurus/plugin-google-gtag": "^3.5.0",
-    "@docusaurus/preset-classic": "^3.4.0",
+    "@docusaurus/core": "3.4.0",
+    "@docusaurus/plugin-content-blog": "3.4.0",
+    "@docusaurus/plugin-google-gtag": "3.4.0",
+    "@docusaurus/preset-classic": "3.4.0",
     "@easyops-cn/docusaurus-search-local": "^0.44.4",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
@@ -27,9 +27,9 @@
     "react-dom": "^18.0.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.4.0",
-    "@docusaurus/tsconfig": "^3.4.0",
-    "@docusaurus/types": "^3.4.0",
+    "@docusaurus/module-type-aliases": "3.4.0",
+    "@docusaurus/tsconfig": "3.4.0",
+    "@docusaurus/types": "3.4.0",
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
     "postcss-import": "^16.1.0",


### PR DESCRIPTION
Provides support for Google Analytics by using `@docusaurus/plugin-google-gtag`,
its important to note that previously used [`@docusaurus/plugin-google-analytics`](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-analytics) is deprecated in favor of `@docusaurus/plugin-google-gtag`.

The Google Tracking ID used is taken from https://github.com/infinyon/infinyon-website/blob/afaa80ac7d422ffcf9b77c78c423241e667a651b/layouts/partials/header-footer/footer-scripts.html#L14