### PR TITLE
fix: use fluvio.io google tracking id

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -80,7 +80,7 @@ const config: Config = {
     [
       "@docusaurus/plugin-google-gtag",
       {
-        trackingID: "G-R7V7KJ5G2Z",
+        trackingID: "G-KCNH9XETDX",
         anonymizeIP: true,
       },
     ],


### PR DESCRIPTION
Uses the same tracking id as from fluvio.io.