### PR TITLE
fix: copy behavior support for embedded specials

### DIFF
--- a/docs/cloud/tutorials/github-to-discord.mdx
+++ b/docs/cloud/tutorials/github-to-discord.mdx
@@ -112,7 +112,7 @@ $ fluvio cloud secret set DISCORD_TOKEN <webhook-token>
 Download the smartmodules used by the connectors to your cluster:
 
 
-```bash
+```bash copy="cmd"
 $ fluvio hub sm download infinyon/jolt@x.y.z
 $ fluvio hub sm download infinyon-labs/stars-forks-changes@x.y.z
 ```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:dev": "vitest"
   },
   "dependencies": {
     "@docusaurus/core": "3.4.0",

--- a/src/functions/copy-behavior.ts
+++ b/src/functions/copy-behavior.ts
@@ -32,54 +32,6 @@ export function parseCodeBlockCopy(metastring?: string): CopyBehavior {
   );
 }
 
-// Copies full text clearing "special characters" like "$" and ">>" used in code blocks.
-//
-// We want to keep text hierarchy for examples like YAML which is used widely or Rust
-// code blocks.
-function copyFullText(text: string): string {
-  const isSingleLine = !text.includes('\n');
-
-  let buff = '';
-  let prevToken: string | undefined = undefined;
-
-  while (text.length) {
-    const token: string = text[0];
-    const nextToken: string | undefined = text[1];
-    const isFirstToken = !prevToken || prevToken === NON_BREAKING_SPACE || prevToken === '\n';
-
-    text = text.slice(1);
-
-    if (token === '$') {
-      if (isFirstToken) {
-        buff += NON_BREAKING_SPACE;
-        prevToken = NON_BREAKING_SPACE;
-        continue;
-      }
-
-      buff += token;
-      prevToken = token;
-      continue;
-    }
-
-    if (token === '>' && nextToken === '>') {
-      text = text.slice(1);
-      buff += NON_BREAKING_SPACE;
-      buff += NON_BREAKING_SPACE;
-      prevToken = NON_BREAKING_SPACE;
-      continue;
-    }
-
-    buff += token;
-    prevToken = token;
-  }
-
-  if (isSingleLine) {
-    return buff.trim();
-  }
-
-  return buff;
-}
-
 function copyFirstLine(text: string): string {
   const final = text.split('\n')[0];
 
@@ -112,12 +64,9 @@ export function textWithCopyBehavior(text: string, behavior: CopyBehavior): stri
   switch (behavior) {
     case CopyBehavior.FirstLine:
       return copyFirstLine(text);
-    case CopyBehavior.FullText:
-      return copyFullText(text);
     case CopyBehavior.Commands:
       return copyCommands(text);
     default:
-      console.warn(`Invalid copy behavior ${behavior}`);
       return text;
   }
 }

--- a/src/functions/copy-behavior.ts
+++ b/src/functions/copy-behavior.ts
@@ -32,6 +32,10 @@ export function parseCodeBlockCopy(metastring?: string): CopyBehavior {
   );
 }
 
+// Copies full text clearing "special characters" like "$" and ">>" used in code blocks.
+//
+// We want to keep text hierarchy for examples like YAML which is used widely or Rust
+// code blocks.
 function copyFullText(text: string): string {
   const isSingleLine = !text.includes('\n');
 

--- a/src/functions/copy-behavior.ts
+++ b/src/functions/copy-behavior.ts
@@ -1,6 +1,7 @@
 export enum CopyBehavior {
   FirstLine = "fl",
   FullText = "full",
+  Commands = "cmd",
 }
 
 const CODE_BLOCK_COPY_REGEXP = /copy=(?<quote>["'])(?<copy>.*?)\1/;
@@ -89,12 +90,28 @@ function copyFirstLine(text: string): string {
   return final;
 }
 
+function copyCommands(text: string): string {
+  return text.split('\n').map((line) => {
+    const trimmed = line.trim();
+
+    if (trimmed.startsWith('$')) {
+      return trimmed.slice(1).trim();
+    }
+
+    if (trimmed.startsWith('>>')) {
+      return trimmed.slice(2).trim();
+    }
+  }).join('\n');
+}
+
 export function textWithCopyBehavior(text: string, behavior: CopyBehavior): string {
   switch (behavior) {
     case CopyBehavior.FirstLine:
       return copyFirstLine(text);
     case CopyBehavior.FullText:
       return copyFullText(text);
+    case CopyBehavior.Commands:
+      return copyCommands(text);
     default:
       console.warn(`Invalid copy behavior ${behavior}`);
       return text;

--- a/src/functions/copy-behavior.ts
+++ b/src/functions/copy-behavior.ts
@@ -32,16 +32,27 @@ export function parseCodeBlockCopy(metastring?: string): CopyBehavior {
 }
 
 function copyFullText(text: string): string {
+  const isSingleLine = !text.includes('\n');
+
   let buff = '';
+  let prevToken: string | undefined = undefined;
 
   while (text.length) {
     const token: string = text[0];
     const nextToken: string | undefined = text[1];
+    const isFirstToken = !prevToken || prevToken === NON_BREAKING_SPACE || prevToken === '\n';
 
     text = text.slice(1);
 
     if (token === '$') {
-      buff += NON_BREAKING_SPACE;
+      if (isFirstToken) {
+        buff += NON_BREAKING_SPACE;
+        prevToken = NON_BREAKING_SPACE;
+        continue;
+      }
+
+      buff += token;
+      prevToken = token;
       continue;
     }
 
@@ -49,11 +60,16 @@ function copyFullText(text: string): string {
       text = text.slice(1);
       buff += NON_BREAKING_SPACE;
       buff += NON_BREAKING_SPACE;
-
+      prevToken = NON_BREAKING_SPACE;
       continue;
     }
 
     buff += token;
+    prevToken = token;
+  }
+
+  if (isSingleLine) {
+    return buff.trim();
   }
 
   return buff;

--- a/src/theme/CodeBlock/CopyButton/index.tsx
+++ b/src/theme/CodeBlock/CopyButton/index.tsx
@@ -17,7 +17,7 @@ export default function CopyButton({code, className, copyBehavior}: Props & {
   const [isCopied, setIsCopied] = useState(false);
   const copyTimeout = useRef<number | undefined>(undefined);
   const handleCopyCode = useCallback(() => {
-  const text = textWithCopyBehavior(code, copyBehavior);
+    const text = textWithCopyBehavior(code, copyBehavior);
 
     copy(text);
     setIsCopied(true);

--- a/tests/copy-behavior.test.ts
+++ b/tests/copy-behavior.test.ts
@@ -132,4 +132,34 @@ describe("copy behavior smoke tests", () => {
       want,
     );
   });
+
+  it(`clears multiline commands for bash ("$") examples`, () => {
+    const have = `
+$ fluvio cluster create
+$ fluvio topic create my-topic
+$ fluvio produce my-topic`;
+    const want = `
+fluvio cluster create
+fluvio topic create my-topic
+fluvio produce my-topic`;
+
+    expect(textWithCopyBehavior(have, CopyBehavior.Commands)).toStrictEqual(
+      want,
+    );
+  });
+
+  it(`clears multiline commands for sdf (">>") examples`, () => {
+    const have = `
+>> show state filter-service/filter-questions/metrics
+>> select dataflow wordcount-window-simple
+>> exit`;
+    const want = `
+show state filter-service/filter-questions/metrics
+select dataflow wordcount-window-simple
+exit`;
+
+    expect(textWithCopyBehavior(have, CopyBehavior.Commands)).toStrictEqual(
+      want,
+    );
+  });
 });

--- a/tests/copy-behavior.test.ts
+++ b/tests/copy-behavior.test.ts
@@ -137,7 +137,7 @@ describe("copy behavior smoke tests", () => {
     const have = `
 $ fluvio cluster create
 $ fluvio topic create my-topic
-$ fluvio produce my-topic`;
+$ fluvio produce my-topic  `; // checks for trailing spaces
     const want = `
 fluvio cluster create
 fluvio topic create my-topic
@@ -152,7 +152,7 @@ fluvio produce my-topic`;
     const have = `
 >> show state filter-service/filter-questions/metrics
 >> select dataflow wordcount-window-simple
->> exit`;
+>> exit  `; // checks for trailing spaces
     const want = `
 show state filter-service/filter-questions/metrics
 select dataflow wordcount-window-simple

--- a/tests/copy-behavior.test.ts
+++ b/tests/copy-behavior.test.ts
@@ -1,20 +1,27 @@
-import { expect, describe, it } from 'vitest';
+import { expect, describe, it } from "vitest";
 
-import { CopyBehavior, textWithCopyBehavior } from '../src/functions/copy-behavior';
+import {
+  CopyBehavior,
+  textWithCopyBehavior,
+} from "../src/functions/copy-behavior";
 
-describe('copy behavior smoke tests', () => {
+describe("copy behavior smoke tests", () => {
   it(`removes trailing "$" from line when using "fl" behavior`, () => {
-    const have = '$ fluvio topic create my-topic';
-    const want = 'fluvio topic create my-topic';
+    const have = "$ fluvio topic create my-topic";
+    const want = "fluvio topic create my-topic";
 
-    expect(textWithCopyBehavior(have, CopyBehavior.FirstLine)).toStrictEqual(want);
+    expect(textWithCopyBehavior(have, CopyBehavior.FirstLine)).toStrictEqual(
+      want,
+    );
   });
 
   it(`removes trailing ">>" from line when using "fl" behavior`, () => {
-    const have = '>> show state filter-service/filter-questions/metrics';
-    const want = 'show state filter-service/filter-questions/metrics';
+    const have = ">> show state filter-service/filter-questions/metrics";
+    const want = "show state filter-service/filter-questions/metrics";
 
-    expect(textWithCopyBehavior(have, CopyBehavior.FirstLine)).toStrictEqual(want);
+    expect(textWithCopyBehavior(have, CopyBehavior.FirstLine)).toStrictEqual(
+      want,
+    );
   });
 
   it(`removes trailing "$" from line when using "full" behavior`, () => {
@@ -32,7 +39,9 @@ describe('copy behavior smoke tests', () => {
         cat hello-world.txt
       Hello, World!`;
 
-    expect(textWithCopyBehavior(have, CopyBehavior.FullText)).toStrictEqual(want);
+    expect(textWithCopyBehavior(have, CopyBehavior.FullText)).toStrictEqual(
+      want,
+    );
   });
 
   it(`removes ">>" from text using "full" behavior`, () => {
@@ -44,6 +53,83 @@ describe('copy behavior smoke tests', () => {
          show state filter-service/filter-questions/metrics
          show state filter-service/filter-questions/metrics`;
 
-    expect(textWithCopyBehavior(have, CopyBehavior.FullText)).toStrictEqual(want);
+    expect(textWithCopyBehavior(have, CopyBehavior.FullText)).toStrictEqual(
+      want,
+    );
+  });
+
+  it(`allows "$" embedded into text`, () => {
+    const have = `
+      "raw_fact_json":
+        json-key: "$"
+        value:
+          type: "jsonb"
+          required: true`;
+
+    expect(textWithCopyBehavior(have, CopyBehavior.FullText)).toStrictEqual(
+      have,
+    );
+  });
+
+  it(`respects identation for yaml-like`, () => {
+    const have = `
+      apiVersion: 0.5.0
+      meta:
+        name: filter-example
+        version: 0.1.0
+        namespace: examples
+
+      config:
+        converter: raw
+
+      topics:
+        sentences:
+          schema:
+            value:
+              type: string
+
+        questions:
+          schema:
+            value:
+              type: string
+
+      services:
+        filter-service:
+          sources:
+            - type: topic
+              id: sentences
+
+          transforms:
+            - operator: filter
+              run: |
+                fn filter_questions(input: String) -> Result<bool> {
+                  Ok(input.contains("?"))
+                }
+
+          sinks:
+            - type: topic
+              id: questions`;
+
+    expect(textWithCopyBehavior(have, CopyBehavior.FullText)).toStrictEqual(
+      have,
+    );
+  });
+
+  it(`trims single-line snippets with "$"`, () => {
+    const have = `$ fluvio produce sentence`;
+    const want = `fluvio produce sentence`;
+
+    expect(textWithCopyBehavior(have, CopyBehavior.FullText)).toStrictEqual(
+      want,
+    );
+  });
+
+  it(`trims single-line snippets with ">>"`, () => {
+    const have = `>> show state filter-service/filter-questions/metrics`;
+    const want = `show state filter-service/filter-questions/metrics`;
+
+    expect(textWithCopyBehavior(have, CopyBehavior.FullText)).toStrictEqual(
+      want,
+    );
   });
 });

--- a/tests/copy-behavior.test.ts
+++ b/tests/copy-behavior.test.ts
@@ -24,7 +24,7 @@ describe("copy behavior smoke tests", () => {
     );
   });
 
-  it(`removes trailing "$" from line when using "full" behavior`, () => {
+  it(`full-text wont remove trailing "$" from line when using "full" behavior`, () => {
     const have = `
       $ mkdir -p /tmp/hello-world
       $ cd /tmp/hello-world
@@ -33,10 +33,10 @@ describe("copy behavior smoke tests", () => {
       Hello, World!`;
 
     const want = `
-        mkdir -p /tmp/hello-world
-        cd /tmp/hello-world
-        echo "Hello, World!" > hello-world.txt
-        cat hello-world.txt
+      $ mkdir -p /tmp/hello-world
+      $ cd /tmp/hello-world
+      $ echo "Hello, World!" > hello-world.txt
+      $ cat hello-world.txt
       Hello, World!`;
 
     expect(textWithCopyBehavior(have, CopyBehavior.FullText)).toStrictEqual(
@@ -44,14 +44,14 @@ describe("copy behavior smoke tests", () => {
     );
   });
 
-  it(`removes ">>" from text using "full" behavior`, () => {
+  it(`full-text wont remove ">>" from text using "full" behavior`, () => {
     const have = `
       >> show state filter-service/filter-questions/metrics
       >> show state filter-service/filter-questions/metrics`;
 
     const want = `
-         show state filter-service/filter-questions/metrics
-         show state filter-service/filter-questions/metrics`;
+      >> show state filter-service/filter-questions/metrics
+      >> show state filter-service/filter-questions/metrics`;
 
     expect(textWithCopyBehavior(have, CopyBehavior.FullText)).toStrictEqual(
       want,
@@ -115,18 +115,18 @@ describe("copy behavior smoke tests", () => {
     );
   });
 
-  it(`trims single-line snippets with "$"`, () => {
+  it(`full-text wont trim single-line snippets with "$"`, () => {
     const have = `$ fluvio produce sentence`;
-    const want = `fluvio produce sentence`;
+    const want = `$ fluvio produce sentence`;
 
     expect(textWithCopyBehavior(have, CopyBehavior.FullText)).toStrictEqual(
       want,
     );
   });
 
-  it(`trims single-line snippets with ">>"`, () => {
+  it(`full-text wont trim single-line snippets with ">>"`, () => {
     const have = `>> show state filter-service/filter-questions/metrics`;
-    const want = `show state filter-service/filter-questions/metrics`;
+    const want = `>> show state filter-service/filter-questions/metrics`;
 
     expect(textWithCopyBehavior(have, CopyBehavior.FullText)).toStrictEqual(
       want,


### PR DESCRIPTION
Introduces the `cmd` copy behavior for subsequent command snippets like:

```
$ fluvio hub sm download infinyon/jolt@x.y.z
$ fluvio hub sm download infinyon-labs/stars-forks-changes@x.y.z
```

Which when decorated with `copy="cmd"` will be copied as:

```
fluvio hub sm download infinyon/jolt@x.y.z
fluvio hub sm download infinyon-labs/stars-forks-changes@x.y.z
```

Also fixes issue for `copy="full"` (default behavior), where embedded special char(s) are removed.

### Copy Behaviors

Theres 3 possible scenarios:

- **FirstLine**: Where a snippet of code includes output, and the user only wants to use the first line of it.

```bash
$ fluvio topic create hello
Topic "hello" created
```

From this snippet, the first line without the `$ ` is relevant, so we use `copy="fl"`.

- **FullText** (Default Behavior)

Copies full-text as-is, but if text starts with special characters, these special characters are removed.

For these snippets we use `copy="full"`

```bash
      "raw_fact_json":
        json-key: "$"
        value:
          type: "jsonb"
          required: true
```

If we use `full` subsuquent commands we will get spaces at the beginning and end of each
line, this is because we want to maintain indentation. So text like this:

```
      >> show state filter-service/filter-questions/metrics
      >> show state filter-service/filter-questions/metrics
```

Ends up in:

```
         show state filter-service/filter-questions/metrics
         show state filter-service/filter-questions/metrics
```

This is not what we want for subsequent commands, so we do use `cmd` behavior instead.

- **Commands**:

The copy behavior `cmd` will remove special char(s) from the beginning and will trim each
line, allowing us to share sets of commands to execute sequentially.

```
      >> show state filter-service/filter-questions/metrics
      >> show state filter-service/filter-questions/metrics
```

Will end up in:

```
show state filter-service/filter-questions/metrics
show state filter-service/filter-questions/metrics
```

### Examples

**Copy First Line**

![CleanShot 2024-08-21 at 19 24 44](https://github.com/user-attachments/assets/21e174d8-1c1a-401d-b48e-57910ff82ab4)

**Copy Full Text**

![CleanShot 2024-08-21 at 19 27 52](https://github.com/user-attachments/assets/2ebf0e96-df87-4d6a-b09d-39670584e408)

**Copy Commands**

![CleanShot 2024-08-21 at 19 33 49](https://github.com/user-attachments/assets/f6366bb0-7f55-432d-aa0e-ec0952434dd8)

