### PR TITLE
feat(src): `copy="cmd"` filter empty lines

### DIFF
--- a/src/functions/copy-behavior.ts
+++ b/src/functions/copy-behavior.ts
@@ -57,7 +57,7 @@ function copyCommands(text: string): string {
     if (trimmed.startsWith('>>')) {
       return trimmed.slice(2).trim();
     }
-  }).join('\n');
+  }).filter(Boolean).join('\n');
 }
 
 export function textWithCopyBehavior(text: string, behavior: CopyBehavior): string {

--- a/tests/copy-behavior.test.ts
+++ b/tests/copy-behavior.test.ts
@@ -138,8 +138,7 @@ describe("copy behavior smoke tests", () => {
 $ fluvio cluster create
 $ fluvio topic create my-topic
 $ fluvio produce my-topic  `; // checks for trailing spaces
-    const want = `
-fluvio cluster create
+    const want = `fluvio cluster create
 fluvio topic create my-topic
 fluvio produce my-topic`;
 
@@ -153,10 +152,22 @@ fluvio produce my-topic`;
 >> show state filter-service/filter-questions/metrics
 >> select dataflow wordcount-window-simple
 >> exit  `; // checks for trailing spaces
-    const want = `
-show state filter-service/filter-questions/metrics
+    const want = `show state filter-service/filter-questions/metrics
 select dataflow wordcount-window-simple
 exit`;
+
+    expect(textWithCopyBehavior(have, CopyBehavior.Commands)).toStrictEqual(
+      want,
+    );
+  });
+
+  it(`supports multiline clearing`, () => {
+    const have = `$ fluvio consume questions -Bd
+    Are you there?
+    A
+    Bd
+    C`;
+    const want = `fluvio consume questions -Bd`;
 
     expect(textWithCopyBehavior(have, CopyBehavior.Commands)).toStrictEqual(
       want,


### PR DESCRIPTION
Ensures empty lines are not included for `cmd` copy behavior.

Copying:

```
$ fluvio consume questions -Bd
    Are you there?
    A
    Bd
    C
```

Results in:

```
fluvio consume questions -Bd
```