### PR TITLE
Carson/iterate deployment docs

### DIFF
--- a/sdf/deployment.mdx
+++ b/sdf/deployment.mdx
@@ -48,7 +48,7 @@ $> sdf worker list
 ```
 The `*` indicates the current selected worker.
 
-SDF only supports running a single HOST worker for each machine since a single worker can support many dataflows.  If you try to create another worker, you will get an error message.
+SDF only supports running a single host worker for each machine since a single worker can support many dataflows.  If you try to create another worker, you will get an error message.
 
 ```bash
 $ sdf worker create main2
@@ -57,24 +57,16 @@ There is already a host worker with pid 20686 running.  Please terminate it firs
 ```
 
 Shutting down a worker will terminate all running dataflow and worker processes. 
+
 ```bash
 $> sdf worker shutdown main
 Shutting down pid: 20688
 Host worker: main has been shutdown
 ```
 
-Even though the host worker is shutdown and removed from the profile, the dataflow files and state are still persisted.   You can restart the worker and the dataflow will resume.
+Even though the host worker is shutdown and removed from the profile, the dataflow files and state are still persisted.  You can restart the worker and the dataflow will resume.
 
-For example, if you have dataflow `fraud-detector` and `car-processor` running in the worker and you shut down the worker, the dataflow process will be terminated.   But you can resume by recreating the HOST worker.
-
-```bash
-$> sdf worker create main
-```
-
-The local worker stores the dataflow state in the local file system.  The dataflow state is stored in the `~/.sdf/<cluster>/worker/<dataflow>`.
-For the `local` cluster, files will be stored in `~/.sdf/local/worker/dataflows`.
-
-if you have deleted the fluvio cluster, the worker needs to be manually shutdown and created again.  This limitation will be removed in a future release
+Host workers store the dataflow state in the local file system at `~/.sdf/local/worker/dataflows`.  If you have deleted your local fluvio cluster, the worker needs to be manually shutdown and created again.  This limitation will be removed in a future release
 
 
 ### Remote Workers
@@ -87,7 +79,7 @@ Typical lifecycle for using remote worker:
 
 Note that there are many ways to manage the remote worker.  You can use Kubernetes, Docker, Systemd, Terraform, Ansible, or any other tool that can manage the server process and ensure it can restart when server is rebooted.  Please contact InfinyOn support for more information.
 
-InfinyOn cloud is a simplest way to use the remote worker.   When you create a cluster in InfinyOn cloud, it will automatically provision and sync worker for you.  
+InfinyOn cloud is a simplest way to use the remote worker.  When you create a cluster in InfinyOn cloud, it will automatically provision and sync worker for you.
 
 The worker is automatically register when you create the cluster.  By default, worker is name as cluster name.
 
@@ -153,6 +145,9 @@ finding all available workers:
 ```
 
 With `-all` option, it will display `version` of the discovered worker. 
+
+// check if this is true for remote workers
+The dataflow state is stored in the `~/.sdf/<cluster>/worker/<dataflow>`.
 
 ### Workers on InfinyOn Cloud
 

--- a/sdf/deployment.mdx
+++ b/sdf/deployment.mdx
@@ -4,23 +4,19 @@ description: Deployment of dataflow via a Worker
 sidebar_position: 60
 ---
 
-# Introduction
+## Introduction
 
 When you use the `run` command to execute a dataflow, it runs within the same process as the CLI. This is useful for development and testing because it's easy to start without needing to manage additional resources. It allows for quick testing and validation of the dataflow, and you can easily load and integrate development packages.
 
-For production deployment, the `deploy` command is used to deploy the dataflow on a worker. All operations available in `run` also apply to deploy, with the following differences:
+For production deployment, the `deploy` command is used to deploy the dataflow on a `worker`. All operations available in `run` also apply to deploy, with the following differences:
 - The dataflow is executed on the worker, not within the CLI process. The CLI communicates with the worker on the user's behalf.
-- The dataflow continues running even if the CLI is shut down. It will only terminate if the worker is stopped, shut down, or the dataflow is explicitly stopped or deleted.
+- The dataflow continues running even if the CLI is shut down. It will only terminate if the worker is stopped or shut down, or if the dataflow is explicitly stopped or deleted.
 - Dataflows in the worker only have access to published packages, unlike `run` mode, which allows access to local packages. If you need to use a package, you must publish it first.
 - Multiple dataflows can be deployed on the worker, with each dataflow isolated from the others. They do not share any state or memory but can communicate via Fluvio topics.
 
+To use deployment mode, it's essential to understand what a worker is, and [how to manage a dataflow inside a worker](#managing-dataflows).
 
-To use deployment mode, it's essential to understand the following concepts:
-- Workers
-- Deploying dataflows to workers
-- Dataflow lifecycle within a worker
-
-# Workers
+## Workers
 
 A worker is the deployment target for a dataflow and must be created and provisioned before deploying a dataflow. The worker can run anywhere as long as it can connect to the same Fluvio cluster. If you're using InfinyOn Cloud, the worker is automatically provisioned.
 
@@ -134,7 +130,7 @@ To unregister the worker after you are done with and no longer need,  you can us
 $> sdf worker unregister <name>
 ```
 
-## Managing workers
+### Managing workers
 
 Workers must be registered before deploying a dataflow. The CLI provides commands to manage workers, including creating, listing, switching, and deleting them.
 
@@ -160,8 +156,27 @@ finding all available workers:
 
 With `-all` option, it will display `version` of the discovered worker. 
 
+### Workers on InfinyOn Cloud
 
-# Deploying dataflow
+With InfinyOn Cloud, there is no need to manage the worker.  It provisions the worker for you.  It also sync profile when cluster is created.
+
+For example, creating cloud cluster will automatically provision and create SDF worker profile.
+
+```bash
+$> fluvio cloud login --use-oauth2
+$> fluvio cloud cluster create
+Creating cluster...
+Done!
+Downloading cluster config
+Registered sdf worker: jellyfish
+Switched to new profile: jellyfish
+```
+
+You can unregister the cloud worker like any other remote worker.
+
+## Managing Dataflows
+
+### Deploying Dataflows to Workers
 
 Once worker is selected, you can deploy the dataflow using `deploy` command:
 
@@ -175,8 +190,6 @@ The deploy command is similar to the run command. It deploys the dataflow and st
 Error: No workers. run `sdf worker create` to create one.
 ```
 
-## Managing dataflow in worker
-
 When you are running dataflow in the worker, it will indicate name of the worker in the prompt:
 
 ```bash
@@ -184,7 +197,7 @@ $> sdf deploy
 [main] >> show state
 ```
 
-## Listing and selecting dataflow
+### Listing and selecting dataflow
 
 To list all dataflows running in the worker, you can use the `show dataflow` command which shows the fully qualified name of the dataflow and its status.
 
@@ -212,22 +225,7 @@ To select the dataflow, you can use `dataflow select` with the fully qualified d
 dataflow switched to: myorg/wordcount-simple@0.10
 ```
 
-## Deleting dataflow
-
-To delete the dataflow, you can use the `dataflow delete` command.
-
-After you delete the dataflow, it will no longer be listed in the dataflow list.
-
-```bash
-[jolly-pond]>> delete dataflow myorg/wordcount-simple@0.10 
-    Dataflow                           Status           Last Updated  
- *  myorg/user-job-map@0.1.0           running          10 minutes ago
-```
-
-Note that since `myorg/wordcount-simple@0.10 ` is deleted, it is no longer listed in the dataflow list.
-
-
-## Advanced: Stopping and Restarting dataflow
+### Stopping and Restarting dataflow
 
 In certain cases, you want to stop the dataflow but not delete it.  You can use the `stop` command.
 
@@ -242,36 +240,16 @@ And restart:
 
 Note that `stop` is not persistent.  If worker is restarted, the dataflow will be restarted. 
 
-# Using worker in InfinyOn Cloud
+### Deleting dataflow
 
-With InfinyOn Cloud, there is no need to manage the worker.  It provisions the worker for you.  It also sync profile when cluster is created.
+To delete the dataflow, you can use the `dataflow delete` command.
 
-For example, creating cloud cluster will automatically provision and create SDF worker profile.
-
-```bash
-$> fluvio cloud login --use-oauth2
-$> fluvio cloud cluster create
-Creating cluster...
-Done!
-Downloading cluster config
-Registered sdf worker: jellyfish
-Switched to new profile: jellyfish
-```
-
-You can unregister the cloud worker like any other remote worker.
-
-
-# Advanced: Starting remote worker
-
-To start worker as remote worker, you can use `launch` command:
+After you delete the dataflow, it will no longer be listed in the dataflow list.
 
 ```bash
-$> sdf worker launch --base-dir <dir> --worker-id <worker-id>
+[jolly-pond]>> delete dataflow myorg/wordcount-simple@0.10 
+    Dataflow                           Status           Last Updated  
+ *  myorg/user-job-map@0.1.0           running          10 minutes ago
 ```
 
-where `base-dir` and `worker-id` are optional parameters.  If you don't specify `base-dir`, it will use the default directory: `/sdf`.
-If you don't specify `worker-id`, it will generate unique id for you.
-
-This script is typically used by devops team to start the worker in the server. 
-
-[CLI]: cli
+Note that since `myorg/wordcount-simple@0.10 ` is deleted, it is no longer listed in the dataflow list.

--- a/sdf/deployment.mdx
+++ b/sdf/deployment.mdx
@@ -16,17 +16,17 @@ For production deployment, the `deploy` command is used to deploy the dataflow o
 
 To use deployment mode, it's essential to understand what a worker is, and [how to manage a dataflow inside a worker](#managing-dataflows).
 
+
 ## Workers
 
 A worker is the deployment target for a dataflow and must be created and provisioned before deploying a dataflow. The worker can run anywhere as long as it can connect to the same Fluvio cluster. If you're using InfinyOn Cloud, the worker is automatically provisioned.
 
 There is no limit to the number of dataflows you can run on each worker, apart from CPU, memory, and disk constraints. For optimal performance, it is recommended to run a single worker per machine.
 
-There are two types of workers: `Host` and `Remote`.  `Host` is a simple worker designed for local deployment without requiring any additional infrastructure.  It is not designed for robust production deployment.  
-For typical production deployment, you will use `Remote` worker.  It is designed to run in the cloud, data center, or edge device.   If you are using InfinyOn Cloud, the `remote` cloud worker is automatically provisioned and registered in your profile. 
+There are two types of workers: `host` and `remote`.  A host worker is a simple worker designed for local deployment without requiring any additional infrastructure.  It is not designed for robust production deployments.  For typical production deployments, you will use remote workers.  Remote workers are designed to run in the cloud, data center, or on edge devices.   If you are using InfinyOn Cloud, the remote cloud worker is automatically provisioned and registered in your profile.
 
-Each worker has a unique identifier for the Fluvio cluster. The worker profile is stored in the local machine and is used to match the worker with the Fluvio cluster. When you switch the Fluvio profile, the worker profile is also switched. Once a worker is selected, it will be used for all dataflow operations until you choose a different worker.
-The worker also human-readable name that is used to identify the worker in the CLI.
+A worker "profile" is maintained for each Fluvio cluster. The worker profile maintains a list of uuids of the cluster's workers, as well as the currently selected worker. When you switch the Fluvio profile, the corresponding worker profile is used automatically. Together, the worker profile and Fluvio profile allow the [SDF CLI] to issue commands to the selected worker. Once a worker is selected, it will be used for all dataflow operations until you choose a different worker.  Each worker also has a human-readable name which is used to easily identify the worker in the CLI.
+
 
 ### Host Workers
 
@@ -35,20 +35,20 @@ To create host worker, you can use the following command.
 $> sdf worker create <name>
 ```
 
-This will creates and register a new worker in your machine.  It will run in the background until you shutdown the worker or machine is rebooted.  The name can be anything as long as it is unique for your machine since profile are not shared across different machines.  
+This will creates and register a new worker on your machine.  It will run in the background until you shutdown the worker or machine is rebooted.  The name can be anything.
 
-Once you have created the worker, You can list them. 
+Once you have created a worker, You can view the list of workers on your Fluvio cluster.
 
 ```bash
 $> sdf worker create main
 Worker `main` created for cluster: `local`
 $> sdf worker list
-    NAME  TYPE  CLUSTER  WORKER ID                            
- *  main  Host  local    7fd7eda3-2738-41ef-8edc-9f04e500b919
+    NAME  TYPE  CLUSTER  WORKER ID                             VERSION
+ *  main  Host  local    7fd7eda3-2738-41ef-8edc-9f04e500b919  <your SDF version>
 ```
-The `*` indicates the current selected worker.  
+The `*` indicates the current selected worker.
 
-SDF only support running a single HOST worker for each machine since a single worker can support many dataflow.  If you try to create another worker, you will get an error message.
+SDF only supports running a single HOST worker for each machine since a single worker can support many dataflows.  If you try to create another worker, you will get an error message.
 
 ```bash
 $ sdf worker create main2
@@ -59,13 +59,11 @@ There is already a host worker with pid 20686 running.  Please terminate it firs
 Shutting down a worker will terminate all running dataflow and worker processes. 
 ```bash
 $> sdf worker shutdown main
-sdf worker shutdown main
 Shutting down pid: 20688
-Shutting down pid: 20686
 Host worker: main has been shutdown
 ```
 
-Even though host worker is shutdown and removed from the profile, the dataflow files and state are still persisted.   You can restart the worker and the dataflow will resume.
+Even though the host worker is shutdown and removed from the profile, the dataflow files and state are still persisted.   You can restart the worker and the dataflow will resume.
 
 For example, if you have dataflow `fraud-detector` and `car-processor` running in the worker and you shut down the worker, the dataflow process will be terminated.   But you can resume by recreating the HOST worker.
 
@@ -253,3 +251,5 @@ After you delete the dataflow, it will no longer be listed in the dataflow list.
 ```
 
 Note that since `myorg/wordcount-simple@0.10 ` is deleted, it is no longer listed in the dataflow list.
+
+[SDF CLI]: sdf/cli/index.mdx

--- a/sdf/whatsnew.mdx
+++ b/sdf/whatsnew.mdx
@@ -15,14 +15,14 @@ To upgrade CLI to this version, run the following command:
 
 <CodeBlock language="bash">{InstallFvm}</CodeBlock>
 
-To upgrade host workers, shutdown and restart the worker:
+To upgrade local (host) workers, shutdown and restart the worker:
 
 ```bash
 $ sdf worker shutdown <host-worker-name>
 $ sdf worker create <host-worker-name>
 ```
 
-For upgrading cloud workers, please contact [InfinyOn support](#infinyon-support).
+For upgrading Infinyon Cloud (remote) workers, please contact [InfinyOn support](#infinyon-support).
 
 ### CLI changes
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -21,6 +21,9 @@ code, code * {
   font-family: "Spline Sans Mono", monospace;
   font-style: normal !important;
   font-weight: 400 !important;
+  vertical-align: top;
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 p {


### PR DESCRIPTION
Slightly reworks SDF deployment docs page.

1. Moves paragraph about cloud worker creation under the explanations of creating Host & Remote worker. 
2. Adjusts wording & adds a couple links

Still have to:
1. proof `Remote Worker` section and `Managing Dataflows` section.
2. Clarify difference in use case between user-managed "Remote" worker and Infinyon-managed "Cloud" worker