### PR TITLE
Update docker.mdx

### DIFF
--- a/versioned_docs/version-0.15.2/fluvio/installation/docker.mdx
+++ b/versioned_docs/version-0.15.2/fluvio/installation/docker.mdx
@@ -118,7 +118,7 @@ With the profile set, you are now able to perform Fluvio Client operations
 like listing topics:
 
 ```bash
-fluvio topics list
+fluvio topic list
 ```
 
 ## Teardown


### PR DESCRIPTION
fix typo

it should be `fluvio topic list`

![image](https://github.com/user-attachments/assets/4cf8f575-caa1-4933-ac86-4a5d6a5acc5c)
