### PR TITLE
Minor issue in the docs #394

### DIFF
--- a/docs/fluvio/concepts/operations/monitor.mdx
+++ b/docs/fluvio/concepts/operations/monitor.mdx
@@ -51,4 +51,5 @@ should respectively, match results from
 fluvio cluster spg list
 fluvio cluster spu list
 fluvio partition list
+fluvio topic list
 ```

--- a/docs/fluvio/concepts/operations/monitor.mdx
+++ b/docs/fluvio/concepts/operations/monitor.mdx
@@ -50,6 +50,5 @@ should respectively, match results from
 ```bash
 fluvio cluster spg list
 fluvio cluster spu list
-fluvio cluster topics
-fluvio partitions list
+fluvio partition list
 ```


### PR DESCRIPTION
Removed 'fluvio cluster topics'
Typo in 'fluvio partitions list' 